### PR TITLE
Message object in reaction events

### DIFF
--- a/RevoltSharp/ClientEvents.cs
+++ b/RevoltSharp/ClientEvents.cs
@@ -170,18 +170,18 @@
             OnEmojiDeleted?.Invoke(server, emoji);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Message> OnReactionAdded;
+        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Downloadable<Message>> OnReactionAdded;
 
-        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Message message)
+        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Downloadable<Message> messageDownload)
         {
-            OnReactionAdded?.Invoke(emoji, channel, member, message);
+            OnReactionAdded?.Invoke(emoji, channel, member, messageDownload);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Message> OnReactionRemoved;
+        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Downloadable<Message>> OnReactionRemoved;
 
-        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Message message)
+        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Downloadable<Message> messageDownload)
         {
-            OnReactionRemoved?.Invoke(emoji, channel, member, message);
+            OnReactionRemoved?.Invoke(emoji, channel, member, messageDownload);
         }
     }
 }

--- a/RevoltSharp/ClientEvents.cs
+++ b/RevoltSharp/ClientEvents.cs
@@ -9,6 +9,7 @@
         public delegate void RevoltEvent<TValue>(TValue value);
         public delegate void RevoltEvent<TValue, TValue2>(TValue value, TValue2 value2);
         public delegate void RevoltEvent<TValue, TValue2, TValue3>(TValue values, TValue2 values2, TValue3 value3);
+        public delegate void RevoltEvent<TValue, TValue2, TValue3, TValue4>(TValue values, TValue2 values2, TValue3 value3, TValue4 value4);
 
         /// <summary>
         /// Receive message events from websocket in a <see cref="TextChannel"/> or <seealso cref="GroupChannel"/>
@@ -169,18 +170,18 @@
             OnEmojiDeleted?.Invoke(server, emoji);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember> OnReactionAdded;
+        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Message> OnReactionAdded;
 
-        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member)
+        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Message message)
         {
-            OnReactionAdded?.Invoke(emoji, channel, member);
+            OnReactionAdded?.Invoke(emoji, channel, member, message);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember> OnReactionRemoved;
+        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Message> OnReactionRemoved;
 
-        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member)
+        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Message message)
         {
-            OnReactionRemoved?.Invoke(emoji, channel, member);
+            OnReactionRemoved?.Invoke(emoji, channel, member, message);
         }
     }
 }

--- a/RevoltSharp/ClientEvents.cs
+++ b/RevoltSharp/ClientEvents.cs
@@ -170,16 +170,16 @@
             OnEmojiDeleted?.Invoke(server, emoji);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Downloadable<Message>> OnReactionAdded;
+        public event RevoltEvent<Emoji, ServerChannel, Downloadable<string, ServerMember>, Downloadable<string, Message>> OnReactionAdded;
 
-        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Downloadable<Message> messageDownload)
+        internal void InvokeReactionAdded(Emoji emoji, ServerChannel channel, Downloadable<string, ServerMember> member, Downloadable<string, Message> messageDownload)
         {
             OnReactionAdded?.Invoke(emoji, channel, member, messageDownload);
         }
 
-        public event RevoltEvent<Emoji, ServerChannel, ServerMember, Downloadable<Message>> OnReactionRemoved;
+        public event RevoltEvent<Emoji, ServerChannel, Downloadable<string, ServerMember>, Downloadable<string, Message>> OnReactionRemoved;
 
-        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Downloadable<Message> messageDownload)
+        internal void InvokeReactionRemoved(Emoji emoji, ServerChannel channel, Downloadable<string, ServerMember> member, Downloadable<string, Message> messageDownload)
         {
             OnReactionRemoved?.Invoke(emoji, channel, member, messageDownload);
         }

--- a/RevoltSharp/Core/Servers/Server.cs
+++ b/RevoltSharp/Core/Servers/Server.cs
@@ -68,7 +68,7 @@ namespace RevoltSharp
 
         public bool IsNsfw { get; internal set; }
 
-        public ServerMember GetCachedMember(string userId)
+        public ServerMember? GetCachedMember(string userId)
         {
             if (InternalMembers.TryGetValue(userId, out ServerMember member))
                 return member;

--- a/RevoltSharp/Downloadable.cs
+++ b/RevoltSharp/Downloadable.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+
+namespace RevoltSharp; 
+
+public class Downloadable<T> {
+	private readonly Func<Task<T>> _downloader;
+
+	public Downloadable(Func<Task<T>> downloader) {
+		_downloader = downloader;
+	}
+	
+	public Task<T> DownloadAsync() {
+		return _downloader();
+	}
+}

--- a/RevoltSharp/Downloadable.cs
+++ b/RevoltSharp/Downloadable.cs
@@ -3,14 +3,17 @@ using System.Threading.Tasks;
 
 namespace RevoltSharp; 
 
-public class Downloadable<T> {
-	private readonly Func<Task<T>> _downloader;
+public class Downloadable<TId, TDownload> {
+	private readonly Func<Task<TDownload>> _downloader;
+	
+	public TId Id { get; }
 
-	public Downloadable(Func<Task<T>> downloader) {
+	public Downloadable(TId id, Func<Task<TDownload>> downloader) {
+		Id = id;
 		_downloader = downloader;
 	}
 	
-	public Task<T> DownloadAsync() {
+	public Task<TDownload> DownloadAsync() {
 		return _downloader();
 	}
 }

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -688,7 +688,7 @@ namespace RevoltSharp.WebSocket
                             }
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
-                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId);
+                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
                             Client.InvokeReactionAdded(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
                         }
                         break;
@@ -711,7 +711,7 @@ namespace RevoltSharp.WebSocket
                                 
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
-                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId);
+                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
                             Client.InvokeReactionRemoved(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
                         }
                         break;

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -689,7 +689,7 @@ namespace RevoltSharp.WebSocket
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
                             ServerMember SM = SC.Server.GetCachedMember(@event.UserId);
-                            Client.InvokeReactionAdded(emoji, SC, SM);
+                            Client.InvokeReactionAdded(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
                         }
                         break;
                     case "MessageUnreact":
@@ -712,7 +712,7 @@ namespace RevoltSharp.WebSocket
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
                             ServerMember SM = SC.Server.GetCachedMember(@event.UserId);
-                            Client.InvokeReactionRemoved(emoji, SC, SM);
+                            Client.InvokeReactionRemoved(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
                         }
                         break;
 

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -688,8 +688,9 @@ namespace RevoltSharp.WebSocket
                             }
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
-                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
-                            Client.InvokeReactionAdded(emoji, SC, SM, new Downloadable<Message>(() => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId)));
+                            var SM = new Downloadable<string, ServerMember>(@event.UserId, async () => SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId));
+                            var message = new Downloadable<string, Message>(@event.MessageId, () => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
+                            Client.InvokeReactionAdded(emoji, SC, SM, message);
                         }
                         break;
                     case "MessageUnreact":
@@ -711,8 +712,9 @@ namespace RevoltSharp.WebSocket
                                 
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
-                            ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
-                            Client.InvokeReactionRemoved(emoji, SC, SM, new Downloadable<Message>(() => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId)));
+                            var SM = new Downloadable<string, ServerMember>(@event.UserId, async () => SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId));
+                            var message = new Downloadable<string, Message>(@event.MessageId, () => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
+                            Client.InvokeReactionRemoved(emoji, SC, SM, message);
                         }
                         break;
 

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -689,7 +689,7 @@ namespace RevoltSharp.WebSocket
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
                             ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
-                            Client.InvokeReactionAdded(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
+                            Client.InvokeReactionAdded(emoji, SC, SM, new Downloadable<Message>(() => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId)));
                         }
                         break;
                     case "MessageUnreact":
@@ -712,7 +712,7 @@ namespace RevoltSharp.WebSocket
                             ChannelCache.TryGetValue(@event.ChannelId, out Channel channel);
                             ServerChannel SC = channel as ServerChannel;
                             ServerMember SM = SC.Server.GetCachedMember(@event.UserId) ?? await Client.Rest.GetMemberAsync(SC.ServerId, @event.UserId);
-                            Client.InvokeReactionRemoved(emoji, SC, SM, await Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId));
+                            Client.InvokeReactionRemoved(emoji, SC, SM, new Downloadable<Message>(() => Client.Rest.GetMessageAsync(@event.ChannelId, @event.MessageId)));
                         }
                         break;
 

--- a/TestBot/Program.cs
+++ b/TestBot/Program.cs
@@ -52,11 +52,15 @@ namespace TestBot
         }
 
         private void Client_OnReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
-            Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+            if (member.Id != Client.CurrentUser.Id) {
+                Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+            }
         }
 
         private void Client_OnReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
-            Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+            if (member.Id != Client.CurrentUser.Id) {
+                Client.Rest.RemoveMessageReactionAsync(channel.Id, message.Id, emoji.Id, Client.CurrentUser.Id);
+            }
         }
 
         public RevoltClient Client;

--- a/TestBot/Program.cs
+++ b/TestBot/Program.cs
@@ -51,15 +51,15 @@ namespace TestBot
             client.OnReactionRemoved += Client_OnReactionRemoved;
         }
 
-        private void Client_OnReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
-            if (member.Id != Client.CurrentUser.Id) {
-                Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+        private void Client_OnReactionAdded(Emoji emoji, ServerChannel channel, Downloadable<string, ServerMember> memberDownload, Downloadable<string, Message> messageDownload) {
+            if (memberDownload.Id != Client.CurrentUser.Id) {
+                Client.Rest.AddMessageReactionAsync(channel.Id, messageDownload.Id, emoji.Id).GetAwaiter().GetResult();
             }
         }
 
-        private void Client_OnReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
-            if (member.Id != Client.CurrentUser.Id) {
-                Client.Rest.RemoveMessageReactionAsync(channel.Id, message.Id, emoji.Id, Client.CurrentUser.Id);
+        private void Client_OnReactionRemoved(Emoji emoji, ServerChannel channel, Downloadable<string, ServerMember> memberDownload, Downloadable<string, Message> messageDownload) {
+            if (memberDownload.Id != Client.CurrentUser.Id) {
+                Client.Rest.RemoveMessageReactionAsync(channel.Id, messageDownload.Id, emoji.Id, Client.CurrentUser.Id).GetAwaiter().GetResult();
             }
         }
 

--- a/TestBot/Program.cs
+++ b/TestBot/Program.cs
@@ -46,10 +46,19 @@ namespace TestBot
         public CommandHandler(RevoltClient client)
         {
             Client = client;
-            client.OnMessageRecieved += message => {
-                Client_OnMessageRecieved(message).GetAwaiter().GetResult();
-            };
+            client.OnMessageRecieved += message => Client_OnMessageRecieved(message).GetAwaiter().GetResult();
+            client.OnReactionAdded += Client_OnReactionAdded;
+            client.OnReactionRemoved += Client_OnReactionRemoved;
         }
+
+        private void Client_OnReactionAdded(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
+            Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+        }
+
+        private void Client_OnReactionRemoved(Emoji emoji, ServerChannel channel, ServerMember member, Message message) {
+            Client.Rest.AddMessageReactionAsync(channel.Id, message.Id, emoji.Id);
+        }
+
         public RevoltClient Client;
         public CommandService Service = new CommandService();
         private async Task Client_OnMessageRecieved(Message msg)


### PR DESCRIPTION
Passes the message object to users for OnReactionAdded and OnReactionRemoved events.

Also adds a testbot feature to demonstrate this; it will now mirror every reaction that gets added or removed.