### PR TITLE
fix EditMessageAsync, ModifyChannelAsync, ModifyRoleAsync

### DIFF
--- a/RevoltSharp/Rest/Helpers/MessageHelper.cs
+++ b/RevoltSharp/Rest/Helpers/MessageHelper.cs
@@ -111,7 +111,8 @@ namespace RevoltSharp
                 Req.content = Optional.Some(content.Value);
             if (embeds != null)
                 Req.embeds = Optional.Some(embeds.Value.Select(x => x.ToJson()).ToArray());
-            return await rest.SendRequestAsync<Message>(RequestType.Patch, $"channels/{channelId}/messages/{messageId}", Req);
+            MessageJson Data = await rest.SendRequestAsync<MessageJson>(RequestType.Patch, $"channels/{channelId}/messages/{messageId}", Req);
+            return Message.Create(rest.Client, Data);
         }
 
 

--- a/TestBot/Commands/CmdTest.cs
+++ b/TestBot/Commands/CmdTest.cs
@@ -260,5 +260,14 @@ namespace TestBot.Commands
                 mention = id[0] == '+'
             }).ToArray());
         }
+        
+        [Command("countdown")]
+        public async Task Countdown() {
+            var message = await Context.Channel.SendMessageAsync("3");
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            await message.EditMessageAsync(new Option<string>("2"));
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            await message.EditMessageAsync(new Option<string>("1"));
+        }
     }
 }


### PR DESCRIPTION
Fixed the response handling of several update/edit functions. They would successfully edit the message, but would throw an exception when trying to deserialize the response to an abstract class.