### PR TITLE
Replace WriteLines with OnLog

### DIFF
--- a/RevoltSharp/Client/LogSeverity.cs
+++ b/RevoltSharp/Client/LogSeverity.cs
@@ -1,0 +1,11 @@
+﻿namespace RevoltSharp;
+
+/// <summary>
+/// The severity of a log message raised by <see cref="ClientEvents.OnLog"/>.
+/// </summary>
+public enum LogSeverity
+{
+    Verbose,
+    Standard,
+    Error,
+}

--- a/RevoltSharp/Client/RevoltClient.cs
+++ b/RevoltSharp/Client/RevoltClient.cs
@@ -148,16 +148,15 @@ public class RevoltClient : ClientEvents
     {
         if (FirstConnection)
         {
+            InvokeLog("Starting...", LogSeverity.Verbose);
+
             FirstConnection = false;
             QueryRequest? Query = await Rest.GetAsync<QueryRequest>("/");
             if (Query == null)
-            {
-                Console.WriteLine("[RevoltSharp] Client failed to connect to the revolt api at " + Config.ApiUrl);
-                throw new RevoltException("Client failed to connect to the revolt api at " + Config.ApiUrl);
-            }
+                InvokeLogAndThrowException($"Client failed to connect to the revolt api at {Config.ApiUrl}");
 
             if (!Uri.IsWellFormedUriString(Query.serverFeatures.imageServer.url, UriKind.Absolute))
-                throw new RevoltException("[RevoltSharp] Server Image server url is an invalid format.");
+                throw new RevoltException("Server Image server url is an invalid format.");
 
             RevoltVersion = Query.revoltVersion;
             Config.Debug.WebsocketUrl = Query.websocketUrl;
@@ -171,7 +170,7 @@ public class RevoltClient : ClientEvents
                 throw new RevoltException("Failed to login to user account.");
 
             CurrentUser = new SelfUser(this, SelfUser);
-            Console.WriteLine($"[RevoltSharp] Started: {SelfUser.Username} ({SelfUser.Id})");
+            InvokeLog($"Started: {SelfUser.Username} ({SelfUser.Id})", LogSeverity.Standard);
             InvokeStarted(CurrentUser);
         }
 


### PR DESCRIPTION
adds a new event delegate to RevoltClient called `OnLog` which provides a message and a log severity. by default, RevoltSharp will log events to the console (old behavior). adding a subscriber to this new event will override the old behavior.

this replaces all the non-debugging instances of `Console.WriteLine` in the code to call `OnLog` instead, allowing users to integrate RevoltSharp into their own logging mechanisms. this also allows the sources of log events to be distinguished. webhook errors will also be logged.