### PR TITLE
Clean up exceptions

### DIFF
--- a/RevoltSharp/Client/RevoltClient.cs
+++ b/RevoltSharp/Client/RevoltClient.cs
@@ -156,17 +156,13 @@ public class RevoltClient : ClientEvents
             {
                 Query = await Rest.GetAsync<QueryRequest>("/", null, true);
             }
-            catch (RevoltRestException re)
-            {
-                InvokeLogAndThrowException($"Client failed to connect to the revolt api at {Config.ApiUrl} due to {re.Message}");
-            } 
             catch (Exception ex)
             {
-                InvokeLogAndThrowException($"Client failed to connect to the revolt api at {Config.ApiUrl} due to " + ex.Message);
+                InvokeLogAndThrowException($"Client failed to connect to the Revolt API at {Config.ApiUrl}. {ex.Message}");
             }
 
             if (!Uri.IsWellFormedUriString(Query.serverFeatures.imageServer.url, UriKind.Absolute))
-                InvokeLogAndThrowException("Server Image server url is an invalid format.");
+                InvokeLogAndThrowException("Server Image server URL is an invalid format.");
 
             RevoltVersion = Query.revoltVersion;
             Config.Debug.WebsocketUrl = Query.websocketUrl;
@@ -178,22 +174,19 @@ public class RevoltClient : ClientEvents
             UserJson? SelfUser = null;
             try
             {
-                SelfUser = await Rest.GetAsync<UserJson>("/users/@me", null, true);
+                SelfUser = await Rest.GetAsync<UserJson>("/users/@me", null, true) ?? throw new RevoltException(null);
             }
             catch (RevoltRestException re)
             {
                 if (re.Code == 401)
-                    InvokeLogAndThrowException($"Failed to login to the {(Config.UserBot ? "user" : "bot")} account, token is invalid.");
+                    throw new RevoltRestException("The token is invalid.", re.Code, re.Type);
                 else
-                    InvokeLogAndThrowException($"Failed to login to the {(Config.UserBot ? "user" : "bot")} account, " + re.Message);
+                    throw re;
             }
             catch (Exception ex)
             {
-                InvokeLogAndThrowException($"Failed to login to the {(Config.UserBot ? "user" : "bot")} account, " + ex.Message);
+                InvokeLogAndThrowException($"Failed to login to the {(Config.UserBot ? "user" : "bot")} account. {ex.Message}");
             }
-
-            if (SelfUser == null)
-                InvokeLogAndThrowException($"Failed to login to the {(Config.UserBot ? "user" : "bot")} account.");
 
             CurrentUser = new SelfUser(this, SelfUser);
             InvokeLog($"Started: {SelfUser.Username} ({SelfUser.Id})", RevoltLogSeverity.Standard);
@@ -228,7 +221,7 @@ public class RevoltClient : ClientEvents
     public async Task StopAsync()
     {
         if (WebSocket == null)
-            throw new RevoltException("Client is in http-only mode.");
+            throw new RevoltException("Client is in HTTP-only mode.");
 
         if (WebSocket.WebSocket != null)
         {

--- a/RevoltSharp/Rest/RevoltRestClient.cs
+++ b/RevoltSharp/Rest/RevoltRestClient.cs
@@ -344,7 +344,7 @@ public class RevoltRestClient
 
 
         if (endpoint == "/" && !Req.IsSuccessStatusCode)
-            throw new RevoltRestException("Major RevoltSharp error occured, Revolt API is down.", 500, RevoltErrorType.Unknown);
+            throw new RevoltRestException("The Revolt API is down. Please try again later.", 500, RevoltErrorType.Unknown);
 
 
 

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -57,7 +57,7 @@ internal class RevoltSocketClient
                 catch (ArgumentException)
                 {
                     if (_firstConnected)
-                        Client.InvokeLogAndThrowException("Client config WEBSOCKET_URL is an invalid format.");
+                        Client.InvokeLogAndThrowException("Client config WebsocketUrl is an invalid format.");
                 }
                 catch (WebSocketException we)
                 {


### PR DESCRIPTION
makes some of the exception code DRY, and cleans up some of the error messages so they're a bit clearer.

eg:
> Client failed to connect to the revolt api at https://api.revolt.chat/ due to Major RevoltSharp error occured, Revolt API is down.

to
> Client failed to connect to the Revolt API at https://api.revolt.chat/. The Revolt API is down. Please try again later.