### PR TITLE
Fix NullReferenceException on SendFileAsync

### DIFF
--- a/RevoltSharp/Extensions/Conditions.cs
+++ b/RevoltSharp/Extensions/Conditions.cs
@@ -88,7 +88,7 @@ internal static class Conditions
 
     internal static void MessageContentLength(string content, string request)
     {
-        if (content.Length > 2000)
+        if (content != null && content.Length > 2000)
             throw new RevoltArgumentException($"Message content is more than 2000 characters for the {request} request.");
     }
 


### PR DESCRIPTION
calling `Channel.SendFileAsync` with null being passed as the `text` parameter (the default parameter) results in a NullReferenceException.

this commit makes `Conditions.MessageContentLength` handle null content as zero length content.