### PR TITLE
Cleanup

### DIFF
--- a/RevoltSharp.Commands/Attributes/GroupAttribute.cs
+++ b/RevoltSharp.Commands/Attributes/GroupAttribute.cs
@@ -11,7 +11,7 @@ public class GroupAttribute : Attribute
     /// <summary>
     ///     Gets the prefix set for the module.
     /// </summary>
-    public string Prefix { get; }
+    public string? Prefix { get; }
 
     /// <inheritdoc />
     public GroupAttribute()

--- a/RevoltSharp.Commands/Attributes/PreconditionAttribute.cs
+++ b/RevoltSharp.Commands/Attributes/PreconditionAttribute.cs
@@ -26,7 +26,7 @@ public abstract class PreconditionAttribute : Attribute
     /// Setting this for a class that doesn't override
     /// this property is a no-op.
     /// </summary>
-    public virtual string ErrorMessage { get { return null; } set { } }
+    public virtual string? ErrorMessage { get { return null; } set { } }
 
     /// <summary>
     ///     Checks if the <paramref name="command"/> has the sufficient permission to be executed.

--- a/RevoltSharp.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/RevoltSharp.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -35,7 +35,9 @@ public class RequireOwnerAttribute : PreconditionAttribute
     public override string? ErrorMessage { get; set; }
 
     /// <inheritdoc />
+#pragma warning disable CS1998
     public override async Task<PreconditionResult> CheckPermissionsAsync(CommandContext context, CommandInfo command, IServiceProvider services)
+#pragma warning restore CS1998
     {
         if (context.Client.CurrentUser.OwnerId == context.User.Id || (context.Client.Config.Owners != null && context.Client.Config.Owners.Any(x => x == context.User.Id)))
             return PreconditionResult.FromSuccess();

--- a/RevoltSharp.Commands/Builders/CommandBuilder.cs
+++ b/RevoltSharp.Commands/Builders/CommandBuilder.cs
@@ -13,12 +13,12 @@ public class CommandBuilder
     private readonly List<string> _aliases;
 
     public ModuleBuilder Module { get; }
-    internal Func<CommandContext, object[], IServiceProvider, CommandInfo, Task> Callback { get; set; }
+    internal Func<CommandContext, object[], IServiceProvider, CommandInfo, Task> Callback { get; set; } = null!;
 
-    public string Name { get; set; }
-    public string Summary { get; set; }
-    public string Remarks { get; set; }
-    public string PrimaryAlias { get; set; }
+    public string? Name { get; set; }
+    public string? Summary { get; set; }
+    public string? Remarks { get; set; }
+    public string? PrimaryAlias { get; set; }
     public int Priority { get; set; }
     public bool IgnoreExtraArgs { get; set; }
 

--- a/RevoltSharp.Commands/Builders/ModuleBuilder.cs
+++ b/RevoltSharp.Commands/Builders/ModuleBuilder.cs
@@ -15,10 +15,10 @@ public class ModuleBuilder
 
     public CommandService Service { get; }
     public ModuleBuilder Parent { get; }
-    public string Name { get; set; }
-    public string Summary { get; set; }
-    public string Remarks { get; set; }
-    public string Group { get; set; }
+    public string? Name { get; set; }
+    public string? Summary { get; set; }
+    public string? Remarks { get; set; }
+    public string? Group { get; set; }
 
     public IReadOnlyList<CommandBuilder> Commands => _commands;
     public IReadOnlyList<ModuleBuilder> Modules => _submodules;
@@ -26,7 +26,7 @@ public class ModuleBuilder
     public IReadOnlyList<Attribute> Attributes => _attributes;
     public IReadOnlyList<string> Aliases => _aliases;
 
-    internal TypeInfo TypeInfo { get; set; }
+    internal TypeInfo? TypeInfo { get; set; }
 
     //Automatic
     internal ModuleBuilder(CommandService service, ModuleBuilder parent)

--- a/RevoltSharp.Commands/Builders/ModuleClassBuilder.cs
+++ b/RevoltSharp.Commands/Builders/ModuleClassBuilder.cs
@@ -11,7 +11,7 @@ internal static class ModuleClassBuilder
 {
     private static readonly TypeInfo ModuleTypeInfo = typeof(IModuleBase).GetTypeInfo();
 
-    public static async Task<IReadOnlyList<TypeInfo>> SearchAsync(Assembly assembly, CommandService service)
+    public static IReadOnlyList<TypeInfo> Search(Assembly assembly)
     {
         bool IsLoadableModule(TypeInfo info)
         {
@@ -41,8 +41,8 @@ internal static class ModuleClassBuilder
     }
 
 
-    public static Task<Dictionary<Type, ModuleInfo>> BuildAsync(CommandService service, IServiceProvider services, params TypeInfo[] validTypes) => BuildAsync(validTypes, service, services);
-    public static async Task<Dictionary<Type, ModuleInfo>> BuildAsync(IEnumerable<TypeInfo> validTypes, CommandService service, IServiceProvider services)
+    public static Dictionary<Type, ModuleInfo> Build(CommandService service, IServiceProvider services, params TypeInfo[] validTypes) => Build(validTypes, service, services);
+    public static Dictionary<Type, ModuleInfo> Build(IEnumerable<TypeInfo> validTypes, CommandService service, IServiceProvider services)
     {
         /*if (!validTypes.Any())
             throw new InvalidOperationException("Could not find any valid modules from the given selection");*/

--- a/RevoltSharp.Commands/Builders/ParameterBuilder.cs
+++ b/RevoltSharp.Commands/Builders/ParameterBuilder.cs
@@ -11,15 +11,15 @@ public class ParameterBuilder
     private readonly List<Attribute> _attributes;
 
     public CommandBuilder Command { get; }
-    public string Name { get; internal set; }
-    public Type ParameterType { get; internal set; }
+    public string? Name { get; internal set; }
+    public Type? ParameterType { get; internal set; }
 
-    public TypeReader TypeReader { get; set; }
+    public TypeReader? TypeReader { get; set; }
     public bool IsOptional { get; set; }
     public bool IsRemainder { get; set; }
     public bool IsMultiple { get; set; }
-    public object DefaultValue { get; set; }
-    public string Summary { get; set; }
+    public object? DefaultValue { get; set; }
+    public string? Summary { get; set; }
 
     public IReadOnlyList<ParameterPreconditionAttribute> Preconditions => _preconditions;
     public IReadOnlyList<Attribute> Attributes => _attributes;
@@ -53,7 +53,7 @@ public class ParameterBuilder
         ParameterType = type;
     }
 
-    private TypeReader GetReader(Type type)
+    private TypeReader? GetReader(Type type)
     {
         CommandService commands = Command.Module.Service;
         if (type.GetTypeInfo().GetCustomAttribute<NamedArgumentTypeAttribute>() != null)

--- a/RevoltSharp.Commands/CommandContext.cs
+++ b/RevoltSharp.Commands/CommandContext.cs
@@ -6,19 +6,19 @@ public class CommandContext
     /// <inheritdoc/>
     public RevoltClient Client { get; }
     /// <inheritdoc/>
-    public Server Server { get; }
+    public Server? Server { get; }
     /// <inheritdoc/>
     public Channel Channel { get; }
     /// <inheritdoc/>
-    public User User { get; }
+    public User? User { get; }
     /// <inheritdoc/>
-    public ServerMember Member { get; }
+    public ServerMember? Member { get; }
     /// <inheritdoc/>
     public UserMessage Message { get; }
 
-    public CommandInfo Command { get; set; }
+    public CommandInfo? Command { get; set; }
 
-    public string Prefix { get; set; }
+    public string? Prefix { get; set; }
 
     /// <summary> Indicates whether the channel that the command is executed in is a private channel. </summary>
     public bool IsPrivate => Channel is DMChannel;
@@ -31,7 +31,7 @@ public class CommandContext
     public CommandContext(RevoltClient client, UserMessage msg)
     {
         Client = client;
-        Channel = msg.Channel;
+        Channel = msg.Channel!;
         User = msg.Author;
         Message = msg;
         if (Channel is TextChannel channel)

--- a/RevoltSharp.Commands/CommandService.cs
+++ b/RevoltSharp.Commands/CommandService.cs
@@ -38,7 +38,7 @@ public class CommandService : IDisposable
     /// <summary>
     /// A command has been executed and will return back success or failed
     /// </summary>
-    public event CommandExecutedEvent<Optional<CommandInfo>, CommandContext, IResult> OnCommandExecuted;
+    public event CommandExecutedEvent<Optional<CommandInfo>, CommandContext, IResult>? OnCommandExecuted;
     internal void InvokeCommandExecuted(Optional<CommandInfo> command, CommandContext context, IResult result)
     {
         OnCommandExecuted?.Invoke(command, context, result);
@@ -184,7 +184,7 @@ public class CommandService : IDisposable
             if (_typedModuleDefs.ContainsKey(type))
                 throw new ArgumentException("This module has already been added.");
 
-            KeyValuePair<Type, ModuleInfo> module = (await ModuleClassBuilder.BuildAsync(this, services, typeInfo).ConfigureAwait(false)).FirstOrDefault();
+            KeyValuePair<Type, ModuleInfo> module = ModuleClassBuilder.Build(this, services, typeInfo).FirstOrDefault();
 
             if (module.Value == default(ModuleInfo))
                 throw new InvalidOperationException($"Could not build the module {type.FullName}, did you pass an invalid type?");
@@ -214,8 +214,8 @@ public class CommandService : IDisposable
         await _moduleLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            IReadOnlyList<TypeInfo> types = await ModuleClassBuilder.SearchAsync(assembly, this).ConfigureAwait(false);
-            Dictionary<Type, ModuleInfo> moduleDefs = await ModuleClassBuilder.BuildAsync(types, this, services).ConfigureAwait(false);
+            IReadOnlyList<TypeInfo> types = ModuleClassBuilder.Search(assembly);
+            Dictionary<Type, ModuleInfo> moduleDefs = ModuleClassBuilder.Build(types, this, services);
 
             foreach (KeyValuePair<Type, ModuleInfo> info in moduleDefs)
             {
@@ -400,13 +400,13 @@ public class CommandService : IDisposable
         TypeReader nullableReader = NullableTypeReader.Create(valueType, valueTypeReader);
         readers[nullableReader.GetType()] = nullableReader;
     }
-    internal IDictionary<Type, TypeReader> GetTypeReaders(Type type)
+    internal IDictionary<Type, TypeReader>? GetTypeReaders(Type type)
     {
         if (_typeReaders.TryGetValue(type, out ConcurrentDictionary<Type, TypeReader> definedTypeReaders))
             return definedTypeReaders;
         return null;
     }
-    internal TypeReader GetDefaultTypeReader(Type type)
+    internal TypeReader? GetDefaultTypeReader(Type type)
     {
         if (_defaultTypeReaders.TryGetValue(type, out TypeReader reader))
             return reader;

--- a/RevoltSharp.Commands/EmptyServiceProvider.cs
+++ b/RevoltSharp.Commands/EmptyServiceProvider.cs
@@ -6,5 +6,5 @@ internal class EmptyServiceProvider : IServiceProvider
 {
     public static readonly EmptyServiceProvider Instance = new EmptyServiceProvider();
 
-    public object GetService(Type serviceType) => null;
+    public object? GetService(Type serviceType) => null;
 }

--- a/RevoltSharp.Commands/Info/CommandInfo.cs
+++ b/RevoltSharp.Commands/Info/CommandInfo.cs
@@ -34,7 +34,7 @@ public class CommandInfo
     /// <summary>
     ///     Gets the name of the command. If none is set, the first alias is used.
     /// </summary>
-    public string Name { get; }
+    public string? Name { get; }
     /// <summary>
     ///     Gets the summary of the command.
     /// </summary>
@@ -42,7 +42,7 @@ public class CommandInfo
     ///     This field returns the summary of the command. <see cref="Summary"/> and <see cref="Remarks"/> can be
     ///     useful in help commands and various implementation that fetches details of the command for the user.
     /// </remarks>
-    public string Summary { get; }
+    public string? Summary { get; }
     /// <summary>
     ///     Gets the remarks of the command.
     /// </summary>
@@ -50,7 +50,7 @@ public class CommandInfo
     ///     This field returns the summary of the command. <see cref="Summary"/> and <see cref="Remarks"/> can be
     ///     useful in help commands and various implementation that fetches details of the command for the user.
     /// </remarks>
-    public string Remarks { get; }
+    public string? Remarks { get; }
     /// <summary>
     ///     Gets the priority of the command. This is used when there are multiple overloads of the command.
     /// </summary>

--- a/RevoltSharp.Commands/Info/ModuleInfo.cs
+++ b/RevoltSharp.Commands/Info/ModuleInfo.cs
@@ -18,19 +18,19 @@ public class ModuleInfo
     /// <summary>
     ///     Gets the name of this module.
     /// </summary>
-    public string Name { get; }
+    public string? Name { get; }
     /// <summary>
     ///     Gets the summary of this module.
     /// </summary>
-    public string Summary { get; }
+    public string? Summary { get; }
     /// <summary>
     ///     Gets the remarks of this module.
     /// </summary>
-    public string Remarks { get; }
+    public string? Remarks { get; }
     /// <summary>
     ///     Gets the group name (main prefix) of this module.
     /// </summary>
-    public string Group { get; }
+    public string? Group { get; }
 
     /// <summary>
     ///     Gets a read-only list of aliases associated with this module.

--- a/RevoltSharp.Commands/Info/ParameterInfo.cs
+++ b/RevoltSharp.Commands/Info/ParameterInfo.cs
@@ -13,7 +13,7 @@ namespace RevoltSharp.Commands;
 [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
 public class ParameterInfo
 {
-    private readonly TypeReader _reader;
+    private readonly TypeReader? _reader;
 
     /// <summary>
     ///     Gets the command that associates with this parameter.
@@ -22,11 +22,11 @@ public class ParameterInfo
     /// <summary>
     ///     Gets the name of this parameter.
     /// </summary>
-    public string Name { get; }
+    public string? Name { get; }
     /// <summary>
     ///     Gets the summary of this parameter.
     /// </summary>
-    public string Summary { get; }
+    public string? Summary { get; }
     /// <summary>
     ///     Gets a value that indicates whether this parameter is optional or not.
     /// </summary>
@@ -39,11 +39,11 @@ public class ParameterInfo
     /// <summary>
     ///     Gets the type of the parameter.
     /// </summary>
-    public Type Type { get; }
+    public Type? Type { get; }
     /// <summary>
     ///     Gets the default value for this optional parameter if applicable.
     /// </summary>
-    public object DefaultValue { get; }
+    public object? DefaultValue { get; }
 
     /// <summary>
     ///     Gets a read-only list of precondition that apply to this parameter.
@@ -93,6 +93,6 @@ public class ParameterInfo
         return await _reader.ReadAsync(context, input, services).ConfigureAwait(false);
     }
 
-    public override string ToString() => Name;
+    public override string? ToString() => Name;
     private string DebuggerDisplay => $"{Name}{(IsOptional ? " (Optional)" : "")}{(IsRemainder ? " (Remainder)" : "")}";
 }

--- a/RevoltSharp.Commands/Readers/EnumTypeReader.cs
+++ b/RevoltSharp.Commands/Readers/EnumTypeReader.cs
@@ -17,7 +17,7 @@ internal static class EnumTypeReader
     }
 }
 
-internal class EnumTypeReader<T> : TypeReader
+internal class EnumTypeReader<T> : TypeReader where T : notnull
 {
     private readonly IReadOnlyDictionary<string, object> _enumsByName;
     private readonly IReadOnlyDictionary<T, object> _enumsByValue;

--- a/RevoltSharp.Commands/Readers/NamedArgumentTypeReader.cs
+++ b/RevoltSharp.Commands/Readers/NamedArgumentTypeReader.cs
@@ -123,7 +123,7 @@ internal sealed class NamedArgumentTypeReader<T> : TypeReader
             }
         }
 
-        async Task<object> ReadArgumentAsync(PropertyInfo prop, string arg)
+        async Task<object?> ReadArgumentAsync(PropertyInfo prop, string arg)
         {
             Type elemType = prop.PropertyType;
             bool isCollection = false;
@@ -154,7 +154,7 @@ internal sealed class NamedArgumentTypeReader<T> : TypeReader
         }
     }
 
-    private static async Task<object> ReadSingle(TypeReader reader, CommandContext context, string arg, IServiceProvider services)
+    private static async Task<object?> ReadSingle(TypeReader reader, CommandContext context, string arg, IServiceProvider services)
     {
         TypeReaderResult readResult = await reader.ReadAsync(context, arg, services).ConfigureAwait(false);
         return (readResult.IsSuccess)

--- a/RevoltSharp.Commands/Readers/PrimitiveTypeReader.cs
+++ b/RevoltSharp.Commands/Readers/PrimitiveTypeReader.cs
@@ -8,7 +8,7 @@ internal static class PrimitiveTypeReader
     public static TypeReader Create(Type type)
     {
         type = typeof(PrimitiveTypeReader<>).MakeGenericType(type);
-        return Activator.CreateInstance(type) as TypeReader;
+        return (Activator.CreateInstance(type) as TypeReader)!;
     }
 }
 

--- a/RevoltSharp.Commands/Results/TypeReaderResult.cs
+++ b/RevoltSharp.Commands/Results/TypeReaderResult.cs
@@ -18,7 +18,7 @@ public struct TypeReaderValue
         Score = score;
     }
 
-    public override string ToString() => Value?.ToString();
+    public override string? ToString() => Value?.ToString();
     private string DebuggerDisplay => $"[{Value}, {Math.Round(Score, 2)}]";
 }
 

--- a/RevoltSharp/Core/AvatarSources.cs
+++ b/RevoltSharp/Core/AvatarSources.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace RevoltSharp;
+
+[Flags]
+public enum AvatarSources
+{
+    Default = 1,
+    User = 2,
+    Server = 4,
+
+    UserOrDefault = Default | User,
+    ServerOrUser = User | Server,
+    Any = Server | User | Default,
+}

--- a/RevoltSharp/Core/Channels/ChannelJson.cs
+++ b/RevoltSharp/Core/Channels/ChannelJson.cs
@@ -6,7 +6,7 @@ namespace RevoltSharp;
 internal class ChannelJson
 {
     [JsonProperty("_id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("channel_type")]
     public ChannelType ChannelType;

--- a/RevoltSharp/Core/Channels/DmChannel.cs
+++ b/RevoltSharp/Core/Channels/DmChannel.cs
@@ -33,7 +33,7 @@ public class DMChannel : Channel
     /// <summary>
     /// The last message id sent in this DM channel.
     /// </summary>
-    public string LastMessageId { get; internal set; }
+    public string? LastMessageId { get; internal set; }
 
     internal override void Update(PartialChannelJson json)
     {

--- a/RevoltSharp/Core/Channels/GroupChannel.cs
+++ b/RevoltSharp/Core/Channels/GroupChannel.cs
@@ -27,8 +27,8 @@ public class GroupChannel : Channel
         }
         Description = model.Description;
         LastMessageId = model.LastMessageId;
-        Name = model.Name;
-        OwnerId = model.OwnerId;
+        Name = model.Name!;
+        OwnerId = model.OwnerId!;
         Permissions = new ChannelPermissions(null, model.Permissions, 0);
         Icon = Attachment.Create(client, model.Icon);
         IsNsfw = model.IsNsfw;
@@ -54,7 +54,7 @@ public class GroupChannel : Channel
     /// <summary>
     /// The last message id sent in this Group channel.
     /// </summary>
-    public string LastMessageId { get; internal set; }
+    public string? LastMessageId { get; internal set; }
 
     /// <summary>
     /// Owner of the channel
@@ -71,7 +71,7 @@ public class GroupChannel : Channel
     /// <summary>
     /// Description of the channel
     /// </summary>
-    public string Description { get; internal set; }
+    public string? Description { get; internal set; }
 
     /// <summary>
     /// Icon attachment of the channel

--- a/RevoltSharp/Core/Channels/ServerChannel.cs
+++ b/RevoltSharp/Core/Channels/ServerChannel.cs
@@ -11,10 +11,10 @@ public class ServerChannel : Channel
 {
     internal ServerChannel(RevoltClient client, ChannelJson model) : base(client, model)
     {
-        ServerId = model.ServerId;
+        ServerId = model.ServerId!;
         DefaultPermissions = new ChannelPermissions(Server, model.DefaultPermissions);
         InternalRolePermissions = model.RolePermissions != null ? model.RolePermissions.ToDictionary(x => x.Key, x => new ChannelPermissions(Server, x.Value)) : new Dictionary<string, ChannelPermissions>();
-        Name = model.Name;
+        Name = model.Name!;
         Description = model.Description;
         Icon = Attachment.Create(client, model.Icon);
     }
@@ -60,7 +60,7 @@ public class ServerChannel : Channel
     /// <summary>
     /// Description of the channel
     /// </summary>
-    public string Description { get; internal set; }
+    public string? Description { get; internal set; }
 
     /// <summary>
     /// Icon attachment of the channel

--- a/RevoltSharp/Core/Channels/TextChannel.cs
+++ b/RevoltSharp/Core/Channels/TextChannel.cs
@@ -15,7 +15,7 @@ public class TextChannel : ServerChannel
     /// <summary>
     /// The last message id sent in this Text channel.
     /// </summary>
-    public string LastMessageId { get; internal set; }
+    public string? LastMessageId { get; internal set; }
 
     /// <summary>
     /// Channel has nsfw content.

--- a/RevoltSharp/Core/Emotes/Emoji.cs
+++ b/RevoltSharp/Core/Emotes/Emoji.cs
@@ -9,7 +9,7 @@ public class Emoji : CreatedEntity
 {
     internal Emoji(RevoltClient client, EmojiJson model) : base(client, model.Id)
     {
-        Name = model.Name;
+        Name = model.Name!;
         CreatorId = model.CreatorId;
         ServerId = model.Parent.ServerId;
         IsAnimated = model.Animated;
@@ -43,7 +43,7 @@ public class Emoji : CreatedEntity
     public bool IsServerEmoji
         => !string.IsNullOrEmpty(ServerId);
 
-    public string ServerId { get; internal set; }
+    public string? ServerId { get; internal set; }
 
     /// <summary>
     /// Server that the Emoji is from.
@@ -53,7 +53,7 @@ public class Emoji : CreatedEntity
     /// </remarks>
     public Server? Server => Client.GetServer(ServerId);
 
-    public string CreatorId { get; internal set; }
+    public string? CreatorId { get; internal set; }
 
     public User? Creator => Client.GetUser(CreatorId);
 

--- a/RevoltSharp/Core/Emotes/EmojiJson.cs
+++ b/RevoltSharp/Core/Emotes/EmojiJson.cs
@@ -5,16 +5,16 @@ namespace RevoltSharp;
 internal class EmojiJson
 {
     [JsonProperty("_id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("name")]
-    public string? Name;
+    public string Name = null!;
 
     [JsonProperty("parent")]
-    public EmojiParentJson? Parent;
+    public EmojiParentJson Parent = null!;
 
     [JsonProperty("creator_id")]
-    public string? CreatorId;
+    public string CreatorId = null!;
 
     [JsonProperty("animated")]
     public bool Animated;
@@ -25,5 +25,5 @@ internal class EmojiJson
 internal class EmojiParentJson
 {
     [JsonProperty("id")]
-    public string? ServerId;
+    public string ServerId = null!;
 }

--- a/RevoltSharp/Core/Enums/ChannelPermissions.cs
+++ b/RevoltSharp/Core/Enums/ChannelPermissions.cs
@@ -12,13 +12,10 @@ public class ChannelPermissions
     public ulong RawDenied { get; internal set; }
     internal ChannelPermissions(Server server, PermissionsJson permissions)
     {
-        if (server != null)
-            Server = server;
+        Server = server;
 
         if (permissions == null)
             return;
-
-
 
         RawAllowed = permissions.Allowed;
         RawDenied = permissions.Denied;
@@ -26,6 +23,7 @@ public class ChannelPermissions
 
     internal ChannelPermissions(Server server, ulong allowed, ulong denied)
     {
+        Server = server;
         RawAllowed = allowed;
         RawDenied = denied;
     }

--- a/RevoltSharp/Core/Enums/ServerPermissions.cs
+++ b/RevoltSharp/Core/Enums/ServerPermissions.cs
@@ -10,16 +10,13 @@ public class ServerPermissions
 
     internal ServerPermissions(Server server, ulong permissions)
     {
-        if (server != null)
-            Server = server;
-
+        Server = server;
         RawServer = permissions;
     }
 
     internal ServerPermissions(Server server, ServerMember member)
     {
-        if (server != null)
-            Server = server;
+        Server = server;
 
         if (server != null && server.OwnerId == member.Id)
         {

--- a/RevoltSharp/Core/Messages/Attachment.cs
+++ b/RevoltSharp/Core/Messages/Attachment.cs
@@ -72,7 +72,11 @@ public class Attachment : CreatedEntity
     /// <summary>
     /// The URL of the attachment.
     /// </summary>
-    public string GetUrl(int? size = null) => $"{Client.Config.Debug.UploadUrl}{Tag}/{Id}/{Filename}{(size != null ? $"?size={size}" : null)}";
+    public string GetUrl(int? size = null)
+    {
+        Conditions.ImageSizeLength(size, "GetUrl");
+        return $"{Client.Config.Debug.UploadUrl}{Tag}/{Id}/{Filename}{(size != null ? $"?size={size}" : null)}";
+    }
 
     internal static Attachment? Create(RevoltClient client, AttachmentJson model)
     {

--- a/RevoltSharp/Core/Messages/Attachment.cs
+++ b/RevoltSharp/Core/Messages/Attachment.cs
@@ -12,14 +12,11 @@ public class Attachment : CreatedEntity
         Tag = model.Tag;
         Filename = model.Filename;
         Size = model.Size;
-        if (model.Metadata != null)
-        {
-            Type = model.Metadata.Type;
-            Width = model.Metadata.Width;
-            Height = model.Metadata.Height;
-        }
-        Deleted = model.Deleted;
-        Reported = model.Reported;
+        Type = model.Metadata.Type;
+        Width = model.Metadata.Width;
+        Height = model.Metadata.Height;
+        Deleted = model.Deleted ?? false;
+        Reported = model.Reported ?? false;
     }
 
     /// <summary>
@@ -55,12 +52,12 @@ public class Attachment : CreatedEntity
     /// <summary>
     /// The width of the image if the file is an image type.
     /// </summary>
-    public int Width { get; }
+    public int? Width { get; }
 
     /// <summary>
     /// The height of the image if the file is an image type.
     /// </summary>
-    public int Height { get; }
+    public int? Height { get; }
 
     /// <summary>
     /// File has been deleted.
@@ -72,8 +69,10 @@ public class Attachment : CreatedEntity
     /// </summary>
     public bool Reported { get; }
 
-    public string GetUrl()
-        => Client.Config.Debug.UploadUrl + Tag + "/" + Id + "/" + Filename;
+    /// <summary>
+    /// The URL of the attachment.
+    /// </summary>
+    public string GetUrl(int? size = null) => $"{Client.Config.Debug.UploadUrl}{Tag}/{Id}/{Filename}{(size != null ? $"?size={size}" : null)}";
 
     internal static Attachment? Create(RevoltClient client, AttachmentJson model)
     {

--- a/RevoltSharp/Core/Messages/Attachment.cs
+++ b/RevoltSharp/Core/Messages/Attachment.cs
@@ -74,7 +74,7 @@ public class Attachment : CreatedEntity
     /// </summary>
     public string GetUrl(int? size = null)
     {
-        Conditions.ImageSizeLength(size, "GetUrl");
+        Conditions.ImageSizeLength(size, nameof(GetUrl));
         return $"{Client.Config.Debug.UploadUrl}{Tag}/{Id}/{Filename}{(size != null ? $"?size={size}" : null)}";
     }
 

--- a/RevoltSharp/Core/Messages/AttachmentJson.cs
+++ b/RevoltSharp/Core/Messages/AttachmentJson.cs
@@ -5,37 +5,37 @@ namespace RevoltSharp;
 internal class AttachmentJson
 {
     [JsonProperty("_id")]
-    public string? Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonProperty("tag")]
-    public string? Tag { get; set; }
+    public string Tag { get; set; } = null!;
 
     [JsonProperty("filename")]
-    public string? Filename { get; set; }
+    public string Filename { get; set; } = null!;
 
     [JsonProperty("metadata")]
-    public AttachmentMetaJson? Metadata { get; set; }
+    public AttachmentMetaJson Metadata { get; set; } = null!;
 
     [JsonProperty("content_type")]
-    public string? ContentType { get; set; }
+    public string ContentType { get; set; } = null!;
 
     [JsonProperty("size")]
     public int Size { get; set; }
 
     [JsonProperty("deleted")]
-    public bool Deleted { get; set; }
+    public bool? Deleted { get; set; }
 
     [JsonProperty("reported")]
-    public bool Reported { get; set; }
+    public bool? Reported { get; set; }
 }
 internal class AttachmentMetaJson
 {
     [JsonProperty("type")]
-    public string? Type { get; set; }
+    public string Type { get; set; } = null!;
 
     [JsonProperty("width")]
-    public int Width { get; set; }
+    public int? Width { get; set; }
 
     [JsonProperty("height")]
-    public int Height { get; set; }
+    public int? Height { get; set; }
 }

--- a/RevoltSharp/Core/Messages/Embed.cs
+++ b/RevoltSharp/Core/Messages/Embed.cs
@@ -1,4 +1,5 @@
-﻿using Optionals;
+﻿using System;
+using Optionals;
 
 namespace RevoltSharp;
 
@@ -63,10 +64,10 @@ public class MessageEmbed
         switch (Type)
         {
             case EmbedType.Image:
-                Image = new EmbedMedia(null) { Url = model.url, Height = model.height, Width = model.width };
+                Image = new EmbedMedia(model.url, model.width, model.height);
                 break;
             case EmbedType.Video:
-                Video = new EmbedMedia(null) { Url = model.url, Height = model.height, Width = model.width };
+                Video = new EmbedMedia(model.url, model.width, model.height);
                 break;
         }
         Url = model.url;
@@ -99,32 +100,32 @@ public class MessageEmbed
     /// <summary>
     /// Embed url
     /// </summary>
-    public string Url { get; internal set; }
+    public string? Url { get; internal set; }
 
     /// <summary>
     /// Embed icon url
     /// </summary>
-    public string IconUrl { get; internal set; }
+    public string? IconUrl { get; internal set; }
 
     /// <summary>
     /// Embed title
     /// </summary>
-    public string Title { get; internal set; }
+    public string? Title { get; internal set; }
 
     /// <summary>
     /// Embed description
     /// </summary>
-    public string Description { get; internal set; }
+    public string? Description { get; internal set; }
 
     /// <summary>
     /// Embed site name
     /// </summary>
-    public string Site { get; }
+    public string? Site { get; }
 
     /// <summary>
     /// Embed color
     /// </summary>
-    public RevoltColor Color { get; internal set; }
+    public RevoltColor? Color { get; internal set; }
 
     /// <summary>
     /// Embed image attachment
@@ -149,41 +150,35 @@ public class MessageEmbed
 /// </summary>
 public class Embed
 {
-
-    public Embed()
-    {
-
-    }
-
     /// <summary>
     /// Embed url
     /// </summary>
-    public string Url { get; internal set; }
+    public string? Url { get; internal set; }
 
     /// <summary>
     /// Embed icon url
     /// </summary>
-    public string IconUrl { get; internal set; }
+    public string? IconUrl { get; internal set; }
 
     /// <summary>
     /// Embed title
     /// </summary>
-    public string Title { get; internal set; }
+    public string? Title { get; internal set; }
 
     /// <summary>
     /// Embed description
     /// </summary>
-    public string Description { get; internal set; }
+    public string? Description { get; internal set; }
 
     /// <summary>
     /// Embed image url
     /// </summary>
-    public string Image { get; internal set; }
+    public string? Image { get; internal set; }
 
     /// <summary>
     /// Embed color
     /// </summary>
-    public RevoltColor Color { get; internal set; }
+    public RevoltColor? Color { get; internal set; }
 
 
     internal EmbedJson ToJson()
@@ -215,11 +210,20 @@ public class EmbedMedia
     internal EmbedMedia(EmbedMediaJson model)
     {
         if (model == null)
-            return;
-        Url = model.url;
-        Width = model.width;
-        Height = model.height;
+            throw new ArgumentNullException(nameof(model));
+
+        Url = model.URL;
+        Width = model.Width;
+        Height = model.Height;
     }
+
+    internal EmbedMedia(string url, int width, int height)
+    {
+        Url = url;
+        Width = width;
+        Height = height;
+    }
+
     public string Url;
     public int Width;
     public int Height;

--- a/RevoltSharp/Core/Messages/EmbedJson.cs
+++ b/RevoltSharp/Core/Messages/EmbedJson.cs
@@ -28,7 +28,12 @@ internal class EmbedSpecialJson
 }
 internal class EmbedMediaJson
 {
-    public string? url { get; set; }
-    public int width { get; set; }
-    public int height { get; set; }
+    [JsonProperty("url")]
+    public string URL { get; set; } = null!;
+
+    [JsonProperty("width")]
+    public int Width { get; set; }
+
+    [JsonProperty("height")]
+    public int Height { get; set; }
 }

--- a/RevoltSharp/Core/Messages/Message.cs
+++ b/RevoltSharp/Core/Messages/Message.cs
@@ -8,8 +8,18 @@ namespace RevoltSharp;
 public abstract class Message : CreatedEntity
 {
     internal Message(RevoltClient client, MessageJson model)
-        : base(client, model?.Id)
-    { }
+        : base(client, model.Id)
+    {
+        ChannelId = model.Channel;
+        ServerId = null!;
+        AuthorId = model.Author;
+
+        Author = client.GetUser(model.Author);
+        Channel = client.GetChannel(model.Channel);
+
+        if (Channel != null && Channel is ServerChannel SC)
+            ServerId = SC.ServerId;
+    }
 
     internal static Message Create(RevoltClient client, MessageJson model)
     {

--- a/RevoltSharp/Core/Messages/MessageJson.cs
+++ b/RevoltSharp/Core/Messages/MessageJson.cs
@@ -8,7 +8,7 @@ namespace RevoltSharp;
 internal class MessageJson
 {
     [JsonProperty("_id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("type")]
     public string? Type;
@@ -17,10 +17,10 @@ internal class MessageJson
     public string? Nonce;
 
     [JsonProperty("channel")]
-    public string? Channel;
+    public string Channel = null!;
 
     [JsonProperty("author")]
-    public string? Author;
+    public string Author = null!;
 
     [JsonProperty("content")]
     public string? Content;

--- a/RevoltSharp/Core/Messages/MessageMasquerade.cs
+++ b/RevoltSharp/Core/Messages/MessageMasquerade.cs
@@ -27,9 +27,9 @@ public class MessageMasquerade
         return null;
     }
 
-    public string Name { get; }
-    public string Avatar { get; }
-    public RevoltColor Color { get; }
+    public string? Name { get; }
+    public string? Avatar { get; }
+    public RevoltColor? Color { get; }
 
     internal MessageMasqueradeJson ToJson()
     {

--- a/RevoltSharp/Core/Messages/SystemMessage.cs
+++ b/RevoltSharp/Core/Messages/SystemMessage.cs
@@ -10,22 +10,13 @@ public class SystemMessage<Type> : Message where Type : SystemType
     internal SystemMessage(RevoltClient client, MessageJson model, Type type)
         : base(client, model)
     {
-        ChannelId = model.Channel;
-        Channel = client.GetChannel(ChannelId);
-        if (Channel != null && Channel is ServerChannel SC)
-            ServerId = SC.ServerId;
-
-        AuthorId = model.Author;
         Content = type;
-        if (Content != null)
-        {
-            Content.BaseId = model.System.Id;
-            Content.BaseBy = model.System.By;
-            Content.BaseName = model.System.Name;
-            Content.BaseFrom = model.System.From;
-            Content.BaseTo = model.System.To;
-            Content.BaseText = model.System.Content;
-        }
+        Content.BaseId = model.System.Id;
+        Content.BaseBy = model.System.By;
+        Content.BaseName = model.System.Name;
+        Content.BaseFrom = model.System.From;
+        Content.BaseTo = model.System.To;
+        Content.BaseText = model.System.Content;
     }
 }
 public abstract class SystemType
@@ -45,12 +36,12 @@ public class SystemUnknown : SystemType
 {
     public SystemUnknown()
     {
-        Name = BaseName;
-        Text = BaseText;
-        Id = BaseId;
-        By = BaseBy;
-        From = BaseFrom;
-        To = BaseTo;
+        Name = BaseName!;
+        Text = BaseText!;
+        Id = BaseId!;
+        By = BaseBy!;
+        From = BaseFrom!;
+        To = BaseTo!;
     }
 
     public string Name { get; internal set; }
@@ -68,7 +59,7 @@ public class SystemText : SystemType
 {
     public SystemText()
     {
-        Text = BaseText;
+        Text = BaseText!;
     }
     public string Text { get; internal set; }
 }
@@ -80,8 +71,8 @@ public class SystemUserAdded : SystemType
 {
     public SystemUserAdded()
     {
-        Id = BaseId;
-        By = BaseBy;
+        Id = BaseId!;
+        By = BaseBy!;
     }
     public string Id { get; internal set; }
     public string By { get; internal set; }
@@ -94,8 +85,8 @@ public class SystemUserRemoved : SystemType
 {
     public SystemUserRemoved()
     {
-        Id = BaseId;
-        By = BaseBy;
+        Id = BaseId!;
+        By = BaseBy!;
     }
     public string Id { get; internal set; }
     public string By { get; internal set; }
@@ -108,7 +99,7 @@ public class SystemUserJoined : SystemType
 {
     public SystemUserJoined()
     {
-        Id = BaseId;
+        Id = BaseId!;
     }
     public string Id { get; internal set; }
 }
@@ -120,7 +111,7 @@ public class SystemUserLeft : SystemType
 {
     public SystemUserLeft()
     {
-        Id = BaseId;
+        Id = BaseId!;
     }
     public string Id { get; internal set; }
 }
@@ -132,7 +123,7 @@ public class SystemUserKicked : SystemType
 {
     public SystemUserKicked()
     {
-        Id = BaseId;
+        Id = BaseId!;
     }
     public string Id { get; internal set; }
 }
@@ -144,7 +135,7 @@ public class SystemUserBanned : SystemType
 {
     public SystemUserBanned()
     {
-        Id = BaseId;
+        Id = BaseId!;
     }
     public string Id { get; internal set; }
 }
@@ -156,8 +147,8 @@ public class SystemChannelRenamed : SystemType
 {
     public SystemChannelRenamed()
     {
-        Name = BaseName;
-        By = BaseBy;
+        Name = BaseName!;
+        By = BaseBy!;
     }
     public string Name { get; internal set; }
     public string By { get; internal set; }
@@ -170,7 +161,7 @@ public class SystemChannelDescriptionChanged : SystemType
 {
     public SystemChannelDescriptionChanged()
     {
-        By = BaseBy;
+        By = BaseBy!;
     }
     public string By { get; internal set; }
 }
@@ -182,7 +173,7 @@ public class SystemChannelIconChanged : SystemType
 {
     public SystemChannelIconChanged()
     {
-        By = BaseBy;
+        By = BaseBy!;
     }
     public string By { get; internal set; }
 }
@@ -194,8 +185,8 @@ public class SystemChannelOwnershipChanged : SystemType
 {
     public SystemChannelOwnershipChanged()
     {
-        From = BaseFrom;
-        To = BaseTo;
+        From = BaseFrom!;
+        To = BaseTo!;
     }
     public string From { get; internal set; }
     public string To { get; internal set; }

--- a/RevoltSharp/Core/Servers/Invite.cs
+++ b/RevoltSharp/Core/Servers/Invite.cs
@@ -24,7 +24,7 @@ public class Invite : Entity
     public Channel? Channel => Client.GetChannel(ChannelId);
 
     public string ChannelName { get; internal set; }
-    public string ChannelDescription { get; internal set; }
+    public string? ChannelDescription { get; internal set; }
     public string CreatorName { get; internal set; }
     public Attachment? CreatorAvatar { get; internal set; }
     public bool IsServer { get; internal set; }

--- a/RevoltSharp/Core/Servers/InviteJson.cs
+++ b/RevoltSharp/Core/Servers/InviteJson.cs
@@ -5,33 +5,33 @@ namespace RevoltSharp;
 internal class CreateInviteJson
 {
     [JsonProperty("_id")]
-    public string? Code;
+    public string Code = null!;
 
     [JsonProperty("creator")]
-    public string? CreatorId;
+    public string CreatorId = null!;
 
     [JsonProperty("channel")]
-    public string? ChannelId;
+    public string ChannelId = null!;
 
     [JsonProperty("type")]
-    public string? ChannelType;
+    public string ChannelType = null!;
 }
 internal class InviteJson
 {
     [JsonProperty("code")]
-    public string? Code;
+    public string Code = null!;
 
     [JsonProperty("channel_id")]
-    public string? ChannelId;
+    public string ChannelId = null!;
 
     [JsonProperty("channel_name")]
-    public string? ChannelName;
+    public string ChannelName = null!;
 
     [JsonProperty("channel_description")]
     public string? ChannelDescription;
 
     [JsonProperty("user_name")]
-    public string? CreatorName;
+    public string CreatorName = null!;
 
     [JsonProperty("user_avatar")]
     public AttachmentJson? CreatorAvatar;

--- a/RevoltSharp/Core/Servers/RoleJson.cs
+++ b/RevoltSharp/Core/Servers/RoleJson.cs
@@ -9,10 +9,10 @@ internal class RoleJson
     public string? Id;
 
     [JsonProperty("name")]
-    public string? Name;
+    public string Name = null!;
 
     [JsonProperty("permissions")]
-    public PermissionsJson? Permissions;
+    public PermissionsJson Permissions = null!;
 
     [JsonProperty("hoist")]
     public bool Hoist;

--- a/RevoltSharp/Core/Servers/Server.cs
+++ b/RevoltSharp/Core/Servers/Server.cs
@@ -43,12 +43,20 @@ public class Server : CreatedEntity
     {
         if (InternalMembers.TryGetValue(OwnerId, out ServerMember SM))
             return SM;
-        return await Client.Rest.GetMemberAsync(Id, OwnerId);
+
+        //we assume revolt will ALWAYS successfully return an owner. ownerless servers aren't possible on revolt even if the owner gets platform banned.
+        return (await Client.Rest.GetMemberAsync(Id, OwnerId))!;
     }
 
+    /// <summary>
+    /// Name of the server
+    /// </summary>
     public string Name { get; internal set; }
 
-    public string Description { get; internal set; }
+    /// <summary>
+    /// Description for the server
+    /// </summary>
+    public string? Description { get; internal set; }
 
     internal HashSet<string> ChannelIds { get; set; }
 
@@ -65,11 +73,11 @@ public class Server : CreatedEntity
 
     public Attachment? Icon { get; internal set; }
 
-    public string GetIconUrl() => Icon != null ? Icon.GetUrl() : string.Empty;
+    public string? GetIconUrl() => Icon?.GetUrl();
 
     public Attachment? Banner { get; internal set; }
 
-    public string GetBannerUrl() => Banner != null ? Banner.GetUrl() : string.Empty;
+    public string? GetBannerUrl() => Banner?.GetUrl();
 
     public bool HasAnalytics { get; internal set; }
 

--- a/RevoltSharp/Core/Servers/ServerBan.cs
+++ b/RevoltSharp/Core/Servers/ServerBan.cs
@@ -10,7 +10,6 @@ public class ServerBan : CreatedEntity
         Username = json.Username;
         Reason = jsonInfo.Reason;
         Avatar = Attachment.Create(client, json.Avatar);
-
     }
 
     /// <summary>
@@ -23,9 +22,15 @@ public class ServerBan : CreatedEntity
     /// </summary>
     public new DateTimeOffset CreatedAt => base.CreatedAt;
 
+    /// <summary>
+    /// Username of the banned user.
+    /// </summary>
     public string Username { get; }
 
-    public string Reason { get; internal set; }
+    /// <summary>
+    /// Reason for ban creation.
+    /// </summary>
+    public string? Reason { get; internal set; }
 
     public Attachment? Avatar { get; }
 }

--- a/RevoltSharp/Core/Servers/ServerBansJson.cs
+++ b/RevoltSharp/Core/Servers/ServerBansJson.cs
@@ -5,18 +5,18 @@ namespace RevoltSharp.Core.Servers;
 internal class ServerBansJson
 {
     [JsonProperty("users")]
-    public ServerBanUserJson[]? Users;
+    public ServerBanUserJson[] Users = null!;
 
     [JsonProperty("bans")]
-    public ServerBanInfoJson[]? Bans;
+    public ServerBanInfoJson[] Bans = null!;
 }
 internal class ServerBanUserJson
 {
     [JsonProperty("id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("username")]
-    public string? Username;
+    public string Username = null!;
 
     [JsonProperty("avatar")]
     public AttachmentJson? Avatar;
@@ -27,7 +27,7 @@ internal class ServerBanInfoJson
     public string? Reason;
 
     [JsonProperty("_id")]
-    public ServerBanIdJson? Ids;
+    public ServerBanIdJson Id = null!;
 }
 internal class ServerBanIdJson
 {

--- a/RevoltSharp/Core/Servers/ServerJson.cs
+++ b/RevoltSharp/Core/Servers/ServerJson.cs
@@ -7,19 +7,19 @@ namespace RevoltSharp;
 internal class ServerJson
 {
     [JsonProperty("_id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("owner")]
-    public string? Owner;
+    public string Owner = null!;
 
     [JsonProperty("name")]
-    public string? Name;
+    public string Name = null!;
 
     [JsonProperty("description")]
     public string? Description;
 
     [JsonProperty("channels")]
-    public string[]? Channels;
+    public string[] Channels = null!;
 
     [JsonProperty("categories")]
     public CategoryJson[]? Categories;

--- a/RevoltSharp/Core/Servers/ServerMember.cs
+++ b/RevoltSharp/Core/Servers/ServerMember.cs
@@ -63,30 +63,40 @@ public class ServerMember : Entity
     /// </remarks>
     public Attachment? ServerAvatar { get; internal set; }
 
-    /// <inheritdoc cref="User.GetDefaultAvatarUrl()" />
-    public string GetDefaultAvatarUrl()
-        => Client.Config.ApiUrl + "users/" + Id + "/default_avatar";
+    #region Obsolete
+    /// <inheritdoc cref="User.GetDefaultAvatarUrl" />
+    [Obsolete("Use GetAvatarUrlExt instead.")]
+    public string GetDefaultAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Default, size)!;
 
     /// <summary>
     /// Get the avatar url for this member, may be empty.
     /// </summary>
     /// <returns>URL of the image</returns>
-    public string GetServerAvatarUrl()
-        => Avatar != null ? Avatar.GetUrl() : string.Empty;
+    [Obsolete("Use GetAvatarUrlExt instead.")]
+    public string? GetServerAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Server, size)!;
 
     /// <summary>
     /// Get the avatar url of this member or the default Revolt avatar.
     /// </summary>
     /// <returns>URL of the image</returns>
-    public string GetServerAvatarOrDefaultUrl()
-        => Avatar != null ? Avatar.GetUrl() : GetDefaultAvatarUrl();
+    [Obsolete("Use GetAvatarUrlExt instead.")]
+    public string GetServerAvatarOrDefaultUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Server | AvatarSources.Default, size)!;
 
     /// <summary>
     /// Get the avatar url for the member, parent user or default Revolt avatar.
     /// </summary>
-    /// <returns></returns>
-    public string GetServerAvatarOrUserAvatarOrDefaultUrl()
-        => Avatar != null ? Avatar.GetUrl() : User.GetAvatarOrDefaultUrl();
+    [Obsolete("Use GetAvatarUrlExt instead.")]
+    public string GetServerAvatarOrUserAvatarOrDefaultUrl() => GetAvatarUrlExt(AvatarSources.Any)!;
+    #endregion
+
+    /// <inheritdoc cref="User.GetAvatarUrlExt"/>
+    public string? GetAvatarUrlExt(AvatarSources which = AvatarSources.Any, int? size = null)
+    {
+        if (Avatar != null && (which | AvatarSources.Server) != 0)
+            return Avatar.GetUrl(size);
+
+        return User.GetAvatarUrlExt(which, size);
+    }
 
     /// <summary>
     /// List of role IDs that the member has.
@@ -97,7 +107,7 @@ public class ServerMember : Entity
     /// The member is timed out/muted with the specified date time.
     /// </summary>
     /// <remarks>
-    /// <see cref="ServerMember.Timeout"/>.HasValue will be <see langword="false" /> if member is not timed out/muted.
+    /// Will be null if member is not timed out/muted.
     /// </remarks>
     public DateTime? Timeout { get; internal set; }
 

--- a/RevoltSharp/Core/Servers/ServerMember.cs
+++ b/RevoltSharp/Core/Servers/ServerMember.cs
@@ -63,39 +63,13 @@ public class ServerMember : Entity
     /// </remarks>
     public Attachment? ServerAvatar { get; internal set; }
 
-    #region Obsolete
-    /// <inheritdoc cref="User.GetDefaultAvatarUrl" />
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string GetDefaultAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Default, size)!;
-
-    /// <summary>
-    /// Get the avatar url for this member, may be empty.
-    /// </summary>
-    /// <returns>URL of the image</returns>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string? GetServerAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Server, size)!;
-
-    /// <summary>
-    /// Get the avatar url of this member or the default Revolt avatar.
-    /// </summary>
-    /// <returns>URL of the image</returns>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string GetServerAvatarOrDefaultUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Server | AvatarSources.Default, size)!;
-
-    /// <summary>
-    /// Get the avatar url for the member, parent user or default Revolt avatar.
-    /// </summary>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string GetServerAvatarOrUserAvatarOrDefaultUrl() => GetAvatarUrlExt(AvatarSources.Any)!;
-    #endregion
-
-    /// <inheritdoc cref="User.GetAvatarUrlExt"/>
-    public string? GetAvatarUrlExt(AvatarSources which = AvatarSources.Any, int? size = null)
+    /// <inheritdoc cref="User.GetAvatarURL"/>
+    public string? GetAvatarUrl(AvatarSources which = AvatarSources.Any, int? size = null)
     {
         if (Avatar != null && (which | AvatarSources.Server) != 0)
             return Avatar.GetUrl(size);
 
-        return User.GetAvatarUrlExt(which, size);
+        return User.GetAvatarURL(which, size);
     }
 
     /// <summary>
@@ -195,6 +169,31 @@ public class ServerMember : Entity
     /// <inheritdoc cref="User.MutualGroups"/>
     [JsonIgnore]
     public IReadOnlyCollection<GroupChannel> MutualGroups => User.MutualGroups;
+
+
+    /// <inheritdoc cref="User.GetDefaultAvatarUrl" />
+    [Obsolete("Use GetAvatarUrl instead.")]
+    public string GetDefaultAvatarUrl(int? size = null) => GetAvatarUrl(AvatarSources.Default, size)!;
+
+    /// <summary>
+    /// Get the avatar url for this member, may be empty.
+    /// </summary>
+    /// <returns>URL of the image</returns>
+    [Obsolete("Use GetAvatarUrl instead.")]
+    public string? GetServerAvatarUrl(int? size = null) => GetAvatarUrl(AvatarSources.Server, size)!;
+
+    /// <summary>
+    /// Get the avatar url of this member or the default Revolt avatar.
+    /// </summary>
+    /// <returns>URL of the image</returns>
+    [Obsolete("Use GetAvatarUrl instead.")]
+    public string GetServerAvatarOrDefaultUrl(int? size = null) => GetAvatarUrl(AvatarSources.Server | AvatarSources.Default, size)!;
+
+    /// <summary>
+    /// Get the avatar url for the member, parent user or default Revolt avatar.
+    /// </summary>
+    [Obsolete("Use GetAvatarUrl instead.")]
+    public string GetServerAvatarOrUserAvatarOrDefaultUrl() => GetAvatarUrl(AvatarSources.Any)!;
     #endregion
 
 

--- a/RevoltSharp/Core/Servers/ServerMemberJson.cs
+++ b/RevoltSharp/Core/Servers/ServerMemberJson.cs
@@ -7,10 +7,10 @@ namespace RevoltSharp;
 internal class ServerMemberJson
 {
     [JsonProperty("_id")]
-    public ServerMemberIdsJson? Id;
+    public ServerMemberIdsJson Id = null!;
 
     [JsonProperty("nickname")]
-    public string? Nickname;
+    public string Nickname = null!;
 
     [JsonProperty("avatar")]
     public AttachmentJson? Avatar;
@@ -27,8 +27,8 @@ internal class ServerMemberJson
 internal class ServerMemberIdsJson
 {
     [JsonProperty("server")]
-    public string? Server;
+    public string Server = null!;
 
     [JsonProperty("user")]
-    public string? User;
+    public string User = null!;
 }

--- a/RevoltSharp/Core/Updated/MessageUpdatedProperties.cs
+++ b/RevoltSharp/Core/Updated/MessageUpdatedProperties.cs
@@ -10,15 +10,9 @@ public class MessageUpdatedProperties : CreatedEntity
     internal MessageUpdatedProperties(RevoltClient client, MessageUpdateEventJson json) : base(client, json.MessageId)
     {
         Content = json.Data.Content;
-        if (json.Data.Embeds.HasValue)
-        {
-            if (!json.Data.Embeds.HasValue)
-                Embeds = Optional.None<MessageEmbed[]>();
-            else
-                Embeds = Optional.Some(json.Data.Embeds.Value.Select(x => MessageEmbed.Create(x)).ToArray());
-        }
         EditedAt = json.Data.EditedAt;
         ChannelId = json.ChannelId;
+        Embeds = json.Data.Embeds.HasValue ? Optional.Some(json.Data.Embeds.Value.Select(x => MessageEmbed.Create(x)!).ToArray()) : Optional.None<MessageEmbed[]>();
         if (Channel is ServerChannel SC)
             ServerId = SC.ServerId;
     }
@@ -43,7 +37,7 @@ public class MessageUpdatedProperties : CreatedEntity
 
     public Channel? Channel => Client.GetChannel(ChannelId);
 
-    public string ServerId { get; private set; }
+    public string? ServerId { get; private set; }
 
     public Server? Server => Client.GetServer(ServerId);
 

--- a/RevoltSharp/Core/Updated/UserUpdatedProperties.cs
+++ b/RevoltSharp/Core/Updated/UserUpdatedProperties.cs
@@ -6,11 +6,15 @@ public class UserUpdatedProperties
 {
     internal UserUpdatedProperties(RevoltClient client, PartialUserJson json)
     {
-        if (json.status.HasValue)
-            StatusText = Optional.Some(json.status.Value.Text);
+        if (json.Status.HasValue && json.Status.Value.Text != null)
+            StatusText = Optional.Some(json.Status.Value.Text!);
 
-
-        Avatar = json.avatar.ToModel(client);
+        Avatar = json.Avatar.ToModel(client);
+        Online = json.Online;
+        Privileged = json.Privileged;
+        Username = json.Username;
+        Badges = json.Badges;
+        Flags = json.Flags;
     }
 
     public Optional<string> StatusText { get; internal set; }

--- a/RevoltSharp/Core/Users/PartialUserJson.cs
+++ b/RevoltSharp/Core/Users/PartialUserJson.cs
@@ -5,35 +5,34 @@ namespace RevoltSharp;
 
 internal class PartialUserJson
 {
-    [JsonProperty("profile.content")]
-    public Optional<string> ProfileContent;
-
-    [JsonProperty("profile.background")]
-    public Optional<AttachmentJson> ProfileBackground;
-
-    public Optional<UserStatusJson> status;
-
-    public Optional<AttachmentJson> avatar;
-
-    public Optional<bool> online;
-
-    public Optional<bool> privileged;
 
     [JsonProperty("username")]
     public Optional<string> Username;
 
+    [JsonProperty("discriminator")]
+    public Optional<string> Discriminator;
+
     [JsonProperty("display_name")]
     public Optional<string> DisplayName;
 
-    [JsonProperty("discriminator")]
-    public Optional<string> Discriminator;
+    [JsonProperty("profile")]
+    public Optional<ProfileJson> Profile;
+
+    [JsonProperty("status")]
+    public Optional<UserStatusJson> Status;
+
+    [JsonProperty("avatar")]
+    public Optional<AttachmentJson> Avatar;
+
+    [JsonProperty("online")]
+    public Optional<bool> Online;
+
+    [JsonProperty("privileged")]
+    public Optional<bool> Privileged;
 
     [JsonProperty("badges")]
     public Optional<ulong> Badges;
 
     [JsonProperty("flags")]
     public Optional<ulong> Flags;
-
-
-
 }

--- a/RevoltSharp/Core/Users/Profile.cs
+++ b/RevoltSharp/Core/Users/Profile.cs
@@ -8,6 +8,6 @@ public class Profile : Entity
         Background = Attachment.Create(client, model.Background);
     }
 
-    public string Bio { get; internal set; }
-    public Attachment Background { get; internal set; }
+    public string? Bio { get; internal set; }
+    public Attachment? Background { get; internal set; }
 }

--- a/RevoltSharp/Core/Users/SelfUser.cs
+++ b/RevoltSharp/Core/Users/SelfUser.cs
@@ -34,13 +34,4 @@ public class SelfUser : User
     {
         return (SelfUser)this.MemberwiseClone();
     }
-
-    public async Task GetDMChannelAsync()
-        => throw new RevoltException("You can't get the DM channel for the current user/bot account.");
-
-    public async Task BlockAsync()
-        => throw new RevoltException("You can't block the current user/bot account.");
-
-    public async Task UnBlockAsync()
-        => throw new RevoltException("You can't unblock the current user/bot account.");
 }

--- a/RevoltSharp/Core/Users/SelfUser.cs
+++ b/RevoltSharp/Core/Users/SelfUser.cs
@@ -15,7 +15,7 @@ public class SelfUser : User
     public User? Owner
         => Client.GetUser(OwnerId);
 
-    public string ProfileBio { get; internal set; }
+    public string? ProfileBio { get; internal set; }
 
     public Attachment? Background { get; internal set; }
 

--- a/RevoltSharp/Core/Users/User.cs
+++ b/RevoltSharp/Core/Users/User.cs
@@ -116,7 +116,10 @@ public class User : CreatedEntity
             return Avatar.GetUrl(size);
 
         if ((which | AvatarSources.Default) != 0)
+        {
+            Conditions.ImageSizeLength(size, "GetAvatarUrlExt");
             return $"{Client.Config.ApiUrl}users/{Id}/default_avatar{(size != null ? $"?size={size}" : null)}";
+        }
 
         return null;
     }

--- a/RevoltSharp/Core/Users/User.cs
+++ b/RevoltSharp/Core/Users/User.cs
@@ -86,22 +86,15 @@ public class User : CreatedEntity
     /// Get the default revolt avatar url for this user.
     /// </summary>
     /// <returns>URL of the image (No extension)</returns>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string GetDefaultAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.Default, size)!;
-
-    /// <summary>
-    /// Get the user's custom avatar url, may be empty.
-    /// </summary>
-    /// <returns>URL of the image</returns>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string? GetAvatarUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.User, size);
+    [Obsolete("Use GetAvatarURL instead.")]
+    public string GetDefaultAvatarUrl(int? size = null) => GetAvatarURL(AvatarSources.Default, size)!;
 
     /// <summary>
     /// Get the user's custom avatar url or the default revolt avatar url. 
     /// </summary>
     /// <returns>URL of the image</returns>
-    [Obsolete("Use GetAvatarUrlExt instead.")]
-    public string GetAvatarOrDefaultUrl(int? size = null) => GetAvatarUrlExt(AvatarSources.UserOrDefault, size)!;
+    [Obsolete("Use GetAvatarURL instead.")]
+    public string GetAvatarOrDefaultUrl(int? size = null) => GetAvatarURL(AvatarSources.UserOrDefault, size)!;
     #endregion
 
     /// <summary>
@@ -110,7 +103,7 @@ public class User : CreatedEntity
     /// <param name="which">Which avatar to return.</param>
     /// <param name="size"></param>
     /// <returns>URL of the image</returns>
-    public string? GetAvatarUrlExt(AvatarSources which = AvatarSources.Any, int? size = null)
+    public string? GetAvatarURL(AvatarSources which = AvatarSources.Any, int? size = null)
     {
         if (Avatar != null && (which | AvatarSources.User) != 0)
             return Avatar.GetUrl(size);

--- a/RevoltSharp/Core/Users/User.cs
+++ b/RevoltSharp/Core/Users/User.cs
@@ -110,7 +110,7 @@ public class User : CreatedEntity
 
         if ((which | AvatarSources.Default) != 0)
         {
-            Conditions.ImageSizeLength(size, "GetAvatarUrlExt");
+            Conditions.ImageSizeLength(size, nameof(GetAvatarURL));
             return $"{Client.Config.ApiUrl}users/{Id}/default_avatar{(size != null ? $"?size={size}" : null)}";
         }
 

--- a/RevoltSharp/Core/Users/UserJson.cs
+++ b/RevoltSharp/Core/Users/UserJson.cs
@@ -5,16 +5,16 @@ namespace RevoltSharp;
 internal class UserJson
 {
     [JsonProperty("_id")]
-    public string? Id;
+    public string Id = null!;
 
     [JsonProperty("username")]
-    public string? Username;
+    public string Username = null!;
 
     [JsonProperty("display_name")]
     public string? DisplayName;
 
     [JsonProperty("discriminator")]
-    public string? Discriminator;
+    public string Discriminator = null!;
 
     [JsonProperty("avatar")]
     public AttachmentJson? Avatar;
@@ -54,7 +54,7 @@ internal class UserStatusJson
 internal class UserBotJson
 {
     [JsonProperty("owner")]
-    public string? Owner;
+    public string Owner = null!;
 }
 internal class UserProfileJson
 {

--- a/RevoltSharp/Extensions/Conditions.cs
+++ b/RevoltSharp/Extensions/Conditions.cs
@@ -147,4 +147,10 @@ internal static class Conditions
         if (userId == selfId)
             throw new RevoltArgumentException($"Cannot perform the {request} request against yourself.");
     }
+
+    internal static void ImageSizeLength(int? size, string request)
+    {
+        if (size != null && size <= 0)
+            throw new RevoltArgumentException($"Image size cannot be zero for the {request} request.");
+    }
 }

--- a/RevoltSharp/Extensions/Conditions.cs
+++ b/RevoltSharp/Extensions/Conditions.cs
@@ -141,4 +141,10 @@ internal static class Conditions
         if (string.IsNullOrEmpty(rolename))
             throw new RevoltArgumentException($"Role name can't be empty for the {request} request.");
     }
+
+    internal static void NotSelf(string userId, string selfId, string request)
+    {
+        if (userId == selfId)
+            throw new RevoltArgumentException($"Cannot perform the {request} request against yourself.");
+    }
 }

--- a/RevoltSharp/Extensions/Optional/OptionalDeserializerConverter.cs
+++ b/RevoltSharp/Extensions/Optional/OptionalDeserializerConverter.cs
@@ -14,7 +14,7 @@ public class OptionalDeserializerConverter : JsonConverter
         return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Optional<>);
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         if (reader == null) throw new ArgumentNullException(nameof(reader));
         if (objectType == null) throw new ArgumentNullException(nameof(objectType));
@@ -39,7 +39,7 @@ public class OptionalDeserializerConverter : JsonConverter
         return someMethod.Invoke(noneMethod, new[] { innerValue });
     }
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         if (writer == null) throw new ArgumentNullException(nameof(writer));
         if (serializer == null) throw new ArgumentNullException(nameof(serializer));
@@ -54,7 +54,7 @@ public class OptionalDeserializerConverter : JsonConverter
         var hasValueMethod = MakeStaticGenericMethodInfo(nameof(HasValue), innerType);
         var getValueMethod = MakeStaticGenericMethodInfo(nameof(GetValue), innerType);
 
-        var hasValue = (bool)hasValueMethod.Invoke(null, new[] { value });
+        bool hasValue = (bool)hasValueMethod.Invoke(null, new[] { value })!;
 
         if (!hasValue)
         {

--- a/RevoltSharp/Extensions/Optional/OptionalSerializerConverter.cs
+++ b/RevoltSharp/Extensions/Optional/OptionalSerializerConverter.cs
@@ -17,7 +17,7 @@ internal class OptionalSerializerConverter<T> : JsonConverter
         _innerConverter = innerConverter;
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         T obj;
         if (_innerConverter != null)
@@ -34,9 +34,9 @@ internal class OptionalSerializerConverter<T> : JsonConverter
         return Optional.Some(obj);
     }
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
-        value = ((Optional<T>)value).Value;
+        value = ((Optional<T>)value!).Value;
         if (_innerConverter != null)
             _innerConverter.WriteJson(writer, value, serializer);
         else

--- a/RevoltSharp/Extensions/Optional/RevoltContractResolver.cs
+++ b/RevoltSharp/Extensions/Optional/RevoltContractResolver.cs
@@ -34,7 +34,7 @@ public class RevoltContractResolver : DefaultContractResolver
         return property;
     }
 
-    private static JsonConverter GetConverter(JsonProperty property, PropertyInfo propInfo, Type type, int depth)
+    private static JsonConverter? GetConverter(JsonProperty property, PropertyInfo propInfo, Type type, int depth)
     {
         if (type.IsArray)
             return MakeGenericConverter(property, propInfo, typeof(ArrayConverter<>), type.GetElementType(), depth);
@@ -110,7 +110,7 @@ public class RevoltContractResolver : DefaultContractResolver
         return (getter as Func<TOwner, Optional<TValue>>)((TOwner)owner).HasValue;
     }
 
-    private static JsonConverter MakeGenericConverter(JsonProperty property, PropertyInfo propInfo, Type converterType, Type innerType, int depth)
+    private static JsonConverter? MakeGenericConverter(JsonProperty property, PropertyInfo propInfo, Type converterType, Type innerType, int depth)
     {
         TypeInfo genericType = converterType.MakeGenericType(innerType).GetTypeInfo();
         JsonConverter innerConverter = GetConverter(property, propInfo, innerType, depth + 1);
@@ -131,7 +131,7 @@ internal class ArrayConverter<T> : JsonConverter
         _innerConverter = innerConverter;
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         List<T> result = new List<T>();
         if (reader.TokenType == JsonToken.StartArray)
@@ -150,7 +150,7 @@ internal class ArrayConverter<T> : JsonConverter
         }
         return result.ToArray();
     }
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         if (value != null)
         {
@@ -185,7 +185,7 @@ internal class NullableConverter<T> : JsonConverter
         _innerConverter = innerConverter;
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         object value = reader.Value;
         if (value == null)
@@ -194,14 +194,14 @@ internal class NullableConverter<T> : JsonConverter
         {
             T obj;
             if (_innerConverter != null)
-                obj = (T)_innerConverter.ReadJson(reader, typeof(T), null, serializer);
+                obj = (T)_innerConverter.ReadJson(reader, typeof(T), null, serializer)!;
             else
                 obj = serializer.Deserialize<T>(reader);
             return obj;
         }
     }
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         if (value == null)
             writer.WriteNull();

--- a/RevoltSharp/Rest/Helpers/Bot/UserHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Bot/UserHelper.cs
@@ -22,7 +22,7 @@ public static class UserHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<User?> GetUserAsync(this RevoltRestClient rest, string userId)
     {
-        Conditions.UserIdEmpty(userId, "GetUserAsync");
+        Conditions.UserIdEmpty(userId, nameof(GetUserAsync));
 
         if (rest.Client.WebSocket != null && rest.Client.WebSocket.UserCache.TryGetValue(userId, out User User))
             return User;
@@ -51,7 +51,7 @@ public static class UserHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Profile?> GetProfileAsync(this RevoltRestClient rest, string userId)
     {
-        Conditions.UserIdEmpty(userId, "GetProfileAsync");
+        Conditions.UserIdEmpty(userId, nameof(GetProfileAsync));
 
         ProfileJson? Data = await rest.GetAsync<ProfileJson>($"users/{userId}/profile");
         if (Data == null)
@@ -74,7 +74,7 @@ public static class UserHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<DMChannel?> GetUserDMChannelAsync(this RevoltRestClient rest, string userId)
     {
-        Conditions.UserIdEmpty(userId, "GetUserDMChannel");
+        Conditions.UserIdEmpty(userId, nameof(GetUserDMChannelAsync));
 
         ChannelJson? Data = await rest.GetAsync<ChannelJson>($"users/{userId}/dm");
         if (Data == null)
@@ -99,8 +99,8 @@ public static class UserHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<User> BlockUserAsync(this RevoltRestClient rest, string userId)
     {
-        Conditions.UserIdEmpty(userId, "BlockUserAsync");
-        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, "BlockUserAsync");
+        Conditions.UserIdEmpty(userId, nameof(BlockUserAsync));
+        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, nameof(BlockUserAsync));
 
         UserJson Data = await rest.PutAsync<UserJson>($"users/{userId}/block");
         return new User(rest.Client, Data);
@@ -120,8 +120,8 @@ public static class UserHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<User> UnBlockUserAsync(this RevoltRestClient rest, string userId)
     {
-        Conditions.UserIdEmpty(userId, "UnBlockUserAsync");
-        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, "UnBlockUserAsync");
+        Conditions.UserIdEmpty(userId, nameof(UnBlockUserAsync));
+        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, nameof(UnBlockUserAsync));
 
         UserJson Data = await rest.DeleteAsync<UserJson>($"users/{userId}/block");
         return new User(rest.Client, Data);

--- a/RevoltSharp/Rest/Helpers/Bot/UserHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Bot/UserHelper.cs
@@ -100,6 +100,7 @@ public static class UserHelper
     public static async Task<User> BlockUserAsync(this RevoltRestClient rest, string userId)
     {
         Conditions.UserIdEmpty(userId, "BlockUserAsync");
+        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, "BlockUserAsync");
 
         UserJson Data = await rest.PutAsync<UserJson>($"users/{userId}/block");
         return new User(rest.Client, Data);
@@ -120,6 +121,7 @@ public static class UserHelper
     public static async Task<User> UnBlockUserAsync(this RevoltRestClient rest, string userId)
     {
         Conditions.UserIdEmpty(userId, "UnBlockUserAsync");
+        Conditions.NotSelf(userId, rest.Client.CurrentUser.Id, "UnBlockUserAsync");
 
         UserJson Data = await rest.DeleteAsync<UserJson>($"users/{userId}/block");
         return new User(rest.Client, Data);

--- a/RevoltSharp/Rest/Helpers/Messages/ChannelHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Messages/ChannelHelper.cs
@@ -28,7 +28,7 @@ public static class ChannelHelper
     internal static async Task<TValue?> InternalGetChannelAsync<TValue>(this RevoltRestClient rest, string channelId)
         where TValue : Channel
     {
-        Conditions.ChannelIdEmpty(channelId, "GetChannelAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(GetChannelAsync));
 
         if (rest.Client.TryGetChannel(channelId, out Channel chan))
             return (TValue)chan;
@@ -67,12 +67,12 @@ public static class ChannelHelper
 
     internal static async Task<TChannel> InternalModifyChannelAsync<TChannel>(this RevoltRestClient rest, string channelId, Option<string> name = null, Option<string> desc = null, Option<string> iconId = null, Option<bool> nsfw = null, Option<string> owner = null) where TChannel : Channel
     {
-        Conditions.ChannelIdEmpty(channelId, "ModifyChannelAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(ModifyChannelAsync));
 
         ModifyChannelRequest Req = new ModifyChannelRequest();
         if (name != null)
         {
-            Conditions.ChannelNameEmpty(name.Value, "ModifyChannelAsync");
+            Conditions.ChannelNameEmpty(name.Value, nameof(ModifyChannelAsync));
 
             Req.name = Optional.Some(name.Value);
         }
@@ -97,7 +97,7 @@ public static class ChannelHelper
 
         if (owner != null)
         {
-            Conditions.UserIdEmpty(owner.Value, "ModifyChannelAsync");
+            Conditions.UserIdEmpty(owner.Value, nameof(ModifyChannelAsync));
             Req.owner = Optional.Some(owner.Value);
         }
         ChannelJson Json = await rest.PatchAsync<ChannelJson>($"/channels/{channelId}", Req);
@@ -130,7 +130,7 @@ public static class ChannelHelper
 
     internal static async Task InternalDeleteChannelAsync(this RevoltRestClient rest, string channelId)
     {
-        Conditions.ChannelIdEmpty(channelId, "DeleteChannelAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(DeleteChannelAsync));
 
         await rest.DeleteAsync($"/channels/{channelId}");
     }

--- a/RevoltSharp/Rest/Helpers/Messages/GroupChannelHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Messages/GroupChannelHelper.cs
@@ -24,8 +24,8 @@ public static class GroupChannelHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<GroupChannel> CreateGroupChannelAsync(this RevoltRestClient rest, string name, Option<string> description = null, bool isNsfw = false)
     {
-        Conditions.NotAllowedForBots(rest, "CreateGroupChannelAsync");
-        Conditions.ChannelNameEmpty(name, "CreateGroupChannelAsync");
+        Conditions.NotAllowedForBots(rest, nameof(CreateGroupChannelAsync));
+        Conditions.ChannelNameEmpty(name, nameof(CreateGroupChannelAsync));
         CreateChannelRequest Req = new CreateChannelRequest
         {
             name = name,
@@ -55,8 +55,8 @@ public static class GroupChannelHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<IReadOnlyCollection<User>> GetGroupChannelUsersAsync(this RevoltRestClient rest, string channelId)
     {
-        Conditions.NotAllowedForBots(rest, "GetGroupChannelMembersAsync");
-        Conditions.ChannelIdEmpty(channelId, "GetGroupChannelMembersAsync");
+        Conditions.NotAllowedForBots(rest, nameof(GetGroupChannelUsersAsync));
+        Conditions.ChannelIdEmpty(channelId, nameof(GetGroupChannelUsersAsync));
 
         UserJson[]? List = await rest.GetAsync<UserJson[]>($"channels/{channelId}");
         if (List == null)
@@ -106,7 +106,7 @@ public static class GroupChannelHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task LeaveGroupChannelAsync(this RevoltRestClient rest, string channelId)
     {
-        Conditions.ChannelIdEmpty(channelId, "LeaveGroupChannelAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(LeaveGroupChannelAsync));
 
         await rest.DeleteAsync($"/channels/{channelId}");
     }
@@ -126,9 +126,9 @@ public static class GroupChannelHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task AddUserToGroupChannelAsync(this RevoltRestClient rest, string channelId, string userId)
     {
-        Conditions.NotAllowedForBots(rest, "AddUserToGroupChannelAsync");
-        Conditions.ChannelIdEmpty(channelId, "AddUserToGroupChannel");
-        Conditions.UserIdEmpty(userId, "AddUserToGroupChannel");
+        Conditions.NotAllowedForBots(rest, nameof(AddUserToGroupChannelAsync));
+        Conditions.ChannelIdEmpty(channelId, nameof(AddUserToGroupChannelAsync));
+        Conditions.UserIdEmpty(userId, nameof(AddUserToGroupChannelAsync));
 
         await rest.PutAsync<HttpResponseMessage>($"channels/{channelId}/recipients/{userId}");
     }
@@ -148,9 +148,9 @@ public static class GroupChannelHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task RemoveUserFromGroupChannelAsync(this RevoltRestClient rest, string channelId, string userId)
     {
-        Conditions.NotAllowedForBots(rest, "RemoveUserFromGroupChannelAsync");
-        Conditions.ChannelIdEmpty(channelId, "RemoveUserFromGroupChannelAsync");
-        Conditions.UserIdEmpty(userId, "RemoveUserFromGroupChannelAsync");
+        Conditions.NotAllowedForBots(rest, nameof(RemoveUserFromGroupChannelAsync));
+        Conditions.ChannelIdEmpty(channelId, nameof(RemoveUserFromGroupChannelAsync));
+        Conditions.UserIdEmpty(userId, nameof(RemoveUserFromGroupChannelAsync));
 
         await rest.DeleteAsync($"channels/{channelId}/recipients/{userId}");
     }

--- a/RevoltSharp/Rest/Helpers/Messages/MessageHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Messages/MessageHelper.cs
@@ -28,10 +28,10 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<UserMessage> SendMessageAsync(this RevoltRestClient rest, string channelId, string text, Embed[] embeds = null, string[] attachments = null, MessageMasquerade masquerade = null, MessageInteractions interactions = null, MessageReply[] replies = null)
     {
-        Conditions.ChannelIdEmpty(channelId, "SendMessageAsync");
-        Conditions.MessagePropertiesEmpty(text, attachments, embeds, "SendMessageAsync");
-        Conditions.MessageContentLength(text, "SendMessageAsync");
-        Conditions.EmbedsNotAllowedForUsers(rest, embeds, "SendMessageAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(SendMessageAsync));
+        Conditions.MessagePropertiesEmpty(text, attachments, embeds, nameof(SendMessageAsync));
+        Conditions.MessageContentLength(text, nameof(SendMessageAsync));
+        Conditions.EmbedsNotAllowedForUsers(rest, embeds, nameof(SendMessageAsync));
 
         if (embeds != null)
         {
@@ -107,10 +107,10 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<UserMessage> SendFileAsync(this RevoltRestClient rest, string channelId, byte[] bytes, string fileName, string text = null, Embed[] embeds = null, MessageMasquerade masquerade = null, MessageInteractions interactions = null, MessageReply[] replies = null)
     {
-        Conditions.FileBytesEmpty(bytes, "SendFileAsync");
-        Conditions.FileNameEmpty(fileName, "SendFileAsync");
-        Conditions.MessageContentLength(text, "SendFileAsync");
-        Conditions.EmbedsNotAllowedForUsers(rest, embeds, "SendFileAsync");
+        Conditions.FileBytesEmpty(bytes, nameof(SendFileAsync));
+        Conditions.FileNameEmpty(fileName, nameof(SendFileAsync));
+        Conditions.MessageContentLength(text, nameof(SendFileAsync));
+        Conditions.EmbedsNotAllowedForUsers(rest, embeds, nameof(SendFileAsync));
 
         FileAttachment File = await rest.UploadFileAsync(bytes, fileName, UploadFileType.Attachment);
         return await rest.SendMessageAsync(channelId, text, embeds, new string[] { File.Id }, masquerade, interactions, replies).ConfigureAwait(false);
@@ -129,7 +129,7 @@ public static class MessageHelper
 
     public static async Task<IReadOnlyCollection<Message>> GetMessagesAsync(this RevoltRestClient rest, string channelId, int messageCount = 100, bool includeUserDetails = false, string beforeMessageId = "", string afterMessageId = "")
     {
-        Conditions.ChannelIdEmpty(channelId, "GetMessagesAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(GetMessagesAsync));
 
         GetMessagesRequest Req = new GetMessagesRequest
         {
@@ -161,8 +161,8 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Message?> GetMessageAsync(this RevoltRestClient rest, string channelId, string messageId)
     {
-        Conditions.ChannelIdEmpty(channelId, "GetMessageAsync");
-        Conditions.MessageIdEmpty(messageId, "GetMessageAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(GetMessageAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(GetMessageAsync));
 
         MessageJson? Data = await rest.GetAsync<MessageJson>($"channels/{channelId}/messages/{messageId}");
         if (Data == null)
@@ -185,8 +185,8 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<UserMessage> EditMessageAsync(this RevoltRestClient rest, string channelId, string messageId, Option<string> content = null, Option<Embed[]> embeds = null)
     {
-        Conditions.ChannelIdEmpty(channelId, "EditMessageAsync");
-        Conditions.MessageIdEmpty(messageId, "EditMessageAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(EditMessageAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(EditMessageAsync));
 
         SendMessageRequest Req = new SendMessageRequest();
         if (content != null)
@@ -226,8 +226,8 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task DeleteMessageAsync(this RevoltRestClient rest, string channelId, string messageId)
     {
-        Conditions.ChannelIdEmpty(channelId, "DeleteMessageAsync");
-        Conditions.MessageIdEmpty(messageId, "DeleteMessageAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(DeleteMessageAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(DeleteMessageAsync));
 
 
         await rest.DeleteAsync($"channels/{channelId}/messages/{messageId}");
@@ -248,8 +248,8 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task DeleteMessagesAsync(this RevoltRestClient rest, string channelId, string[] messageIds)
     {
-        Conditions.ChannelIdEmpty(channelId, "DeleteMessagesAsync");
-        Conditions.MessageIdEmpty(messageIds, "DeleteMessagesAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(DeleteMessagesAsync));
+        Conditions.MessageIdEmpty(messageIds, nameof(DeleteMessagesAsync));
 
 
         await rest.DeleteAsync($"channels/{channelId}/messages/bulk", new BulkDeleteMessagesRequest
@@ -273,7 +273,7 @@ public static class MessageHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task CloseDMChannelAsync(this RevoltRestClient rest, string channelId)
     {
-        Conditions.ChannelIdEmpty(channelId, "CloseDMChannelAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(CloseDMChannelAsync));
 
         await rest.DeleteAsync($"channels/{channelId}");
     }

--- a/RevoltSharp/Rest/Helpers/Messages/ReactionHelpers.cs
+++ b/RevoltSharp/Rest/Helpers/Messages/ReactionHelpers.cs
@@ -24,9 +24,9 @@ public static class ReactionHelpers
     /// <exception cref="RevoltRestException"></exception>
     public static async Task AddMessageReactionAsync(this RevoltRestClient rest, string channelId, string messageId, string emojiId)
     {
-        Conditions.ChannelIdEmpty(channelId, "AddMessageReactionAsync");
-        Conditions.MessageIdEmpty(messageId, "AddMessageReactionAsync");
-        Conditions.EmojiIdEmpty(emojiId, "AddMessageReactionAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(AddMessageReactionAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(AddMessageReactionAsync));
+        Conditions.EmojiIdEmpty(emojiId, nameof(AddMessageReactionAsync));
 
         await rest.PutAsync<HttpResponseMessage>($"channels/{channelId}/messages/{messageId}/reactions/{emojiId}");
     }
@@ -54,12 +54,12 @@ public static class ReactionHelpers
     /// <exception cref="RevoltRestException"></exception>
     public static async Task RemoveMessageReactionAsync(this RevoltRestClient rest, string channelId, string messageId, string emojiId, string userId, bool removeAll = false)
     {
-        Conditions.ChannelIdEmpty(channelId, "RemoveMessageReactionAsync");
-        Conditions.MessageIdEmpty(messageId, "RemoveMessageReactionAsync");
-        Conditions.EmojiIdEmpty(emojiId, "RemoveMessageReactionAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(RemoveMessageReactionAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(RemoveMessageReactionAsync));
+        Conditions.EmojiIdEmpty(emojiId, nameof(RemoveMessageReactionAsync));
 
         if (!removeAll)
-            Conditions.UserIdEmpty(userId, "RemoveMessageReactionAsync");
+            Conditions.UserIdEmpty(userId, nameof(RemoveMessageReactionAsync));
 
 
         await rest.DeleteAsync($"channels/{channelId}/messages/{messageId}/reactions/{emojiId}?" +
@@ -77,8 +77,8 @@ public static class ReactionHelpers
     /// <exception cref="RevoltRestException"></exception>
     public static async Task RemoveAllMessageReactionsAsync(this RevoltRestClient rest, string channelId, string messageId)
     {
-        Conditions.ChannelIdEmpty(channelId, "RemoveAllMessageReactionsAsync");
-        Conditions.MessageIdEmpty(messageId, "RemoveAllMessageReactionsAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(RemoveAllMessageReactionsAsync));
+        Conditions.MessageIdEmpty(messageId, nameof(RemoveAllMessageReactionsAsync));
 
         await rest.DeleteAsync($"channels/{channelId}/messages/{messageId}/reactions");
     }

--- a/RevoltSharp/Rest/Helpers/Servers/EmojiHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/EmojiHelper.cs
@@ -22,7 +22,7 @@ public static class EmojiHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Emoji?> GetEmojiAsync(this RevoltRestClient rest, string emojiId)
     {
-        Conditions.EmojiIdEmpty(emojiId, "GetEmojiAsync");
+        Conditions.EmojiIdEmpty(emojiId, nameof(GetEmojiAsync));
 
         if (rest.Client.WebSocket != null && rest.Client.WebSocket.EmojiCache.TryGetValue(emojiId, out Emoji emoji))
             return emoji;
@@ -47,7 +47,7 @@ public static class EmojiHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<IReadOnlyCollection<Emoji>> GetEmojisAsync(this RevoltRestClient rest, string serverId)
     {
-        Conditions.ServerIdEmpty(serverId, "GetEmojisAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetEmojisAsync));
 
         EmojiJson[]? Json = await rest.GetAsync<EmojiJson[]>($"/servers/{serverId}/emojis");
         if (Json == null)
@@ -76,9 +76,9 @@ public static class EmojiHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Emoji> CreateEmojiAsync(this RevoltRestClient rest, string serverId, string attachmentId, string name, bool nsfw = false)
     {
-        Conditions.AttachmentIdEmpty(attachmentId, "CreateEmojiAsync");
-        Conditions.ServerIdEmpty(serverId, "CreateEmojiAsync");
-        Conditions.EmojiNameEmpty(name, "CreateEmojiAsync");
+        Conditions.AttachmentIdEmpty(attachmentId, nameof(CreateEmojiAsync));
+        Conditions.ServerIdEmpty(serverId, nameof(CreateEmojiAsync));
+        Conditions.EmojiNameEmpty(name, nameof(CreateEmojiAsync));
 
         EmojiJson Emoji = await rest.PutAsync<EmojiJson>($"/custom/emoji/{attachmentId}", new CreateEmojiRequest
         {
@@ -113,8 +113,8 @@ public static class EmojiHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task DeleteEmojiAsync(this RevoltRestClient rest, string emojiId)
     {
-        Conditions.EmojiIdEmpty(emojiId, "DeleteEmojiAsync");
-        Conditions.NotAllowedForBots(rest, "DeleteEmojiAsync");
+        Conditions.EmojiIdEmpty(emojiId, nameof(DeleteEmojiAsync));
+        Conditions.NotAllowedForBots(rest, nameof(DeleteEmojiAsync));
 
         await rest.DeleteAsync($"/custom/emoji/{emojiId}");
     }

--- a/RevoltSharp/Rest/Helpers/Servers/InviteHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/InviteHelper.cs
@@ -34,7 +34,7 @@ public static class InviteHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task DeleteInviteAsync(this RevoltRestClient rest, string inviteCode)
     {
-        Conditions.InviteCodeEmpty(inviteCode, "DeleteInviteAsync");
+        Conditions.InviteCodeEmpty(inviteCode, nameof(DeleteInviteAsync));
 
         await rest.DeleteAsync($"/invites/{inviteCode}");
     }
@@ -53,7 +53,7 @@ public static class InviteHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<IReadOnlyCollection<Invite>> GetInvitesAsync(this RevoltRestClient rest, string serverId)
     {
-        Conditions.ServerIdEmpty(serverId, "GetInvitesAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetInvitesAsync));
 
         InviteJson[]? Json = await rest.GetAsync<InviteJson[]>($"/servers/{serverId}/invites");
         if (Json == null)
@@ -76,7 +76,7 @@ public static class InviteHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Invite?> GetInviteAsync(this RevoltRestClient rest, string inviteCode)
     {
-        Conditions.InviteCodeEmpty(inviteCode, "GetInviteAsync");
+        Conditions.InviteCodeEmpty(inviteCode, nameof(GetInviteAsync));
 
         InviteJson? Json = await rest.GetAsync<InviteJson>($"/invites/{inviteCode}");
         if (Json == null)
@@ -100,7 +100,7 @@ public static class InviteHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<CreatedInvite> CreateInviteAsync(this RevoltRestClient rest, string channelId)
     {
-        Conditions.ChannelIdEmpty(channelId, "CreateInviteAsync");
+        Conditions.ChannelIdEmpty(channelId, nameof(CreateInviteAsync));
 
         CreateInviteJson Json = await rest.PostAsync<CreateInviteJson>($"/channels/{channelId}/invites");
         return new CreatedInvite(rest.Client, Json);

--- a/RevoltSharp/Rest/Helpers/Servers/MemberHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/MemberHelper.cs
@@ -34,8 +34,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task AddRoleAsync(this RevoltRestClient rest, ServerMember member, string roleId)
     {
-        Conditions.RoleIdEmpty(roleId, "AddRoleAsync");
-        Conditions.OwnerModifyCheck(member, "AddRoleAsync");
+        Conditions.RoleIdEmpty(roleId, nameof(AddRoleAsync));
+        Conditions.OwnerModifyCheck(member, nameof(AddRoleAsync));
 
         if (!member.RolesIds.Any(x => x == roleId))
         {
@@ -65,12 +65,12 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task AddRolesAsync(this RevoltRestClient rest, ServerMember member, string[] roleIds)
     {
-        Conditions.OwnerModifyCheck(member, "AddRolesAsync");
-        Conditions.RoleListEmpty(roleIds, "AddRolesAsync");
+        Conditions.OwnerModifyCheck(member, nameof(AddRolesAsync));
+        Conditions.RoleListEmpty(roleIds, nameof(AddRolesAsync));
 
         foreach (string r in roleIds)
         {
-            Conditions.RoleIdEmpty(r, "AddRolesAsync");
+            Conditions.RoleIdEmpty(r, nameof(AddRolesAsync));
         }
 
         await rest.PatchAsync<HttpResponseMessage>($"servers/{member.ServerId}/members/{member.Id}", new EditMemberRequest
@@ -99,8 +99,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task RemoveRoleAsync(this RevoltRestClient rest, ServerMember member, string roleId)
     {
-        Conditions.RoleIdEmpty(roleId, "RemoveRoleAsync");
-        Conditions.OwnerModifyCheck(member, "RemoveRoleAsync");
+        Conditions.RoleIdEmpty(roleId, nameof(RemoveRoleAsync));
+        Conditions.OwnerModifyCheck(member, nameof(RemoveRoleAsync));
 
         if (member.Roles.Any(x => x.Id == roleId))
         {
@@ -130,11 +130,11 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task RemoveRolesAsync(this RevoltRestClient rest, ServerMember member, string[] roleIds)
     {
-        Conditions.OwnerModifyCheck(member, "RemoveRolesAsync");
-        Conditions.RoleListEmpty(roleIds, "RemoveRolesAsync");
+        Conditions.OwnerModifyCheck(member, nameof(RemoveRolesAsync));
+        Conditions.RoleListEmpty(roleIds, nameof(RemoveRolesAsync));
         foreach (string r in roleIds)
         {
-            Conditions.RoleIdEmpty(r, "RemoveRolesAsync");
+            Conditions.RoleIdEmpty(r, nameof(RemoveRolesAsync));
         }
 
         await rest.PatchAsync<HttpResponseMessage>($"servers/{member.ServerId}/members/{member.Id}", new EditMemberRequest
@@ -158,8 +158,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<ServerMember?> GetMemberAsync(this RevoltRestClient rest, string serverId, string userId)
     {
-        Conditions.ServerIdEmpty(serverId, "GetMemberAsync");
-        Conditions.UserIdEmpty(userId, "GetMemberAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetMemberAsync));
+        Conditions.UserIdEmpty(userId, nameof(GetMemberAsync));
 
         if (rest.Client.TryGetServer(serverId, out Server Server) && Server.InternalMembers.TryGetValue(userId, out ServerMember sm))
             return sm;
@@ -203,7 +203,7 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<IReadOnlyCollection<ServerMember>> GetMembersAsync(this RevoltRestClient rest, string serverId, bool onlineOnly = false)
     {
-        Conditions.ServerIdEmpty(serverId, "GetMembersAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetMembersAsync));
 
         MembersListJson? List = await rest.GetAsync<MembersListJson>($"servers/{serverId}/members?exclude_offline=" + onlineOnly.ToString());
         if (List == null)
@@ -252,8 +252,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task KickMemberAsync(this RevoltRestClient rest, string serverId, string userId)
     {
-        Conditions.ServerIdEmpty(serverId, "KickMemberAsync");
-        Conditions.UserIdEmpty(userId, "KickMemberAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(KickMemberAsync));
+        Conditions.UserIdEmpty(userId, nameof(KickMemberAsync));
 
         await rest.DeleteAsync($"servers/{serverId}/members/{userId}");
     }
@@ -284,8 +284,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<ServerBan> BanMemberAsync(this RevoltRestClient rest, string serverId, string userId, string reason = "")
     {
-        Conditions.ServerIdEmpty(serverId, "BanMemberAsync");
-        Conditions.UserIdEmpty(userId, "BanMemberAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(BanMemberAsync));
+        Conditions.UserIdEmpty(userId, nameof(BanMemberAsync));
 
         ReasonRequest Req = new ReasonRequest();
         if (!string.IsNullOrEmpty(reason))
@@ -313,8 +313,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task UnBanMemberAsync(this RevoltRestClient rest, string serverId, string userId)
     {
-        Conditions.ServerIdEmpty(serverId, "UnbanMemberAsync");
-        Conditions.MemberIdEmpty(userId, "UnbanMemberAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(UnBanMemberAsync));
+        Conditions.MemberIdEmpty(userId, nameof(UnBanMemberAsync));
 
         await rest.DeleteAsync($"servers/{serverId}/bans/{userId}");
     }
@@ -322,7 +322,7 @@ public static class MemberHelper
     /// <inheritdoc cref="ModifyMemberAsync(RevoltRestClient, string, string, Option{string}, Option{Attachment}, Option{DateTime?})" />
     public static Task ModifyAsync(this ServerMember member, Option<string> nickname = null, Option<Attachment> avatar = null, Option<DateTime?> timeout = null)
     {
-        Conditions.OwnerModifyCheck(member, "ModifyMemberAsync");
+        Conditions.OwnerModifyCheck(member, nameof(ModifyAsync));
         return ModifyMemberAsync(member.Client.Rest, member.ServerId, member.Id, nickname, avatar, timeout);
     }
 
@@ -333,14 +333,14 @@ public static class MemberHelper
     /// <inheritdoc cref="ModifyMemberAsync(RevoltRestClient, string, string, Option{string}, Option{Attachment}, Option{DateTime?})" />
     public static Task ModifyMemberAsync(this Server server, string memberId, Option<string> nickname = null, Option<Attachment> avatar = null, Option<DateTime?> timeout = null)
     {
-        Conditions.OwnerModifyCheck(server, memberId, "ModifyMemberAsync");
+        Conditions.OwnerModifyCheck(server, memberId, nameof(ModifyMemberAsync));
         return ModifyMemberAsync(server.Client.Rest, server.Id, memberId, nickname, avatar, timeout);
     }
 
     /// <inheritdoc cref="ModifyMemberAsync(RevoltRestClient, string, string, Option{string}, Option{Attachment}, Option{DateTime?})" />
     public static Task ModifyMemberAsync(this RevoltRestClient rest, Server server, string memberId, Option<string> nickname = null, Option<Attachment> avatar = null, Option<DateTime?> timeout = null)
     {
-        Conditions.OwnerModifyCheck(server, memberId, "ModifyMemberAsync");
+        Conditions.OwnerModifyCheck(server, memberId, nameof(ModifyMemberAsync));
         return ModifyMemberAsync(rest, server.Id, memberId, nickname, avatar, timeout);
     }
 
@@ -351,8 +351,8 @@ public static class MemberHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task ModifyMemberAsync(this RevoltRestClient rest, string serverId, string memberId, Option<string> nickname = null, Option<Attachment> avatar = null, Option<DateTime?> timeout = null)
     {
-        Conditions.ServerIdEmpty(serverId, "ModifyMemberAsync");
-        Conditions.MemberIdEmpty(memberId, "ModifyMemberAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(ModifyMemberAsync));
+        Conditions.MemberIdEmpty(memberId, nameof(ModifyMemberAsync));
 
         EditMemberRequest Req = new EditMemberRequest();
         if (nickname != null)

--- a/RevoltSharp/Rest/Helpers/Servers/RoleHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/RoleHelper.cs
@@ -24,8 +24,8 @@ public static class RoleHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Role> CreateRoleAsync(this RevoltRestClient rest, string serverId, string name, Option<int> rank = null)
     {
-        Conditions.ServerIdEmpty(serverId, "CreateRoleAsync");
-        Conditions.RoleNameEmpty(name, "CreateRoleAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(CreateRoleAsync));
+        Conditions.RoleNameEmpty(name, nameof(CreateRoleAsync));
         CreateRoleRequest Req = new CreateRoleRequest
         {
             name = name
@@ -59,13 +59,13 @@ public static class RoleHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Role> ModifyRoleAsync(this RevoltRestClient rest, string serverId, string roleId, Option<string> name = null, Option<string> color = null, Option<bool> hoist = null, Option<int> rank = null)
     {
-        Conditions.ServerIdEmpty(serverId, "ModifyRoleAsync");
-        Conditions.RoleIdEmpty(roleId, "ModifyRoleAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(ModifyRoleAsync));
+        Conditions.RoleIdEmpty(roleId, nameof(ModifyRoleAsync));
 
         ModifyRoleRequest Req = new ModifyRoleRequest();
         if (name != null)
         {
-            Conditions.RoleNameEmpty(name.Value, "ModifyRoleAsync");
+            Conditions.RoleNameEmpty(name.Value, nameof(ModifyRoleAsync));
             Req.name = Optional.Some(name.Value);
         }
 
@@ -104,8 +104,8 @@ public static class RoleHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task DeleteRoleAsync(this RevoltRestClient rest, string serverId, string roleId)
     {
-        Conditions.ServerIdEmpty(serverId, "DeleteRoleAsync");
-        Conditions.RoleIdEmpty(roleId, "DeleteRoleAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(DeleteRoleAsync));
+        Conditions.RoleIdEmpty(roleId, nameof(DeleteRoleAsync));
 
         await rest.DeleteAsync($"/servers/{serverId}/roles/{roleId}");
     }

--- a/RevoltSharp/Rest/Helpers/Servers/ServerHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/ServerHelper.cs
@@ -59,7 +59,7 @@ public static class ServerHelper
         if (Bans == null)
             return System.Array.Empty<ServerBan>();
 
-        return Bans.Users.Select(x => new ServerBan(rest.Client, x, Bans.Bans.Where(b => b.Ids.UserId == x.Id).FirstOrDefault())).ToImmutableArray();
+        return Bans.Users.Select(x => new ServerBan(rest.Client, x, Bans.Bans.Where(b => b.Id.UserId == x.Id).FirstOrDefault())).ToImmutableArray();
 
     }
 

--- a/RevoltSharp/Rest/Helpers/Servers/ServerHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/ServerHelper.cs
@@ -22,7 +22,7 @@ public static class ServerHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<Server?> GetServerAsync(this RevoltRestClient rest, string serverId)
     {
-        Conditions.ServerIdEmpty(serverId, "GetServerAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetServerAsync));
 
         if (rest.Client.WebSocket != null && rest.Client.WebSocket.ServerCache.TryGetValue(serverId, out Server server))
             return server;
@@ -53,7 +53,7 @@ public static class ServerHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task<IReadOnlyCollection<ServerBan>> GetBansAsync(this RevoltRestClient rest, string serverId)
     {
-        Conditions.ServerIdEmpty(serverId, "GetBansAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(GetBansAsync));
 
         ServerBansJson? Bans = await rest.GetAsync<ServerBansJson>($"/servers/{serverId}/bans");
         if (Bans == null)
@@ -74,7 +74,7 @@ public static class ServerHelper
     /// <exception cref="RevoltRestException"></exception>
     public static async Task LeaveServerAsync(this RevoltRestClient rest, string serverId)
     {
-        Conditions.ServerIdEmpty(serverId, "LeaveServerAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(LeaveServerAsync));
 
         await rest.DeleteAsync($"/servers/{serverId}");
     }

--- a/RevoltSharp/Rest/Helpers/Servers/TextChannelHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/TextChannelHelper.cs
@@ -46,8 +46,8 @@ public static class TextChannelHelper
 
     internal static async Task<TextChannel> InternalCreateTextChannelAsync(this RevoltRestClient rest, string serverId, string name, string description = null, bool nsfw = false)
     {
-        Conditions.ServerIdEmpty(serverId, "CreateTextChannelAsync");
-        Conditions.ChannelNameEmpty(name, "CreateTextChannelAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(CreateTextChannelAsync));
+        Conditions.ChannelNameEmpty(name, nameof(CreateTextChannelAsync));
 
         CreateChannelRequest Req = new CreateChannelRequest
         {

--- a/RevoltSharp/Rest/Helpers/Servers/VoiceChannelHelper.cs
+++ b/RevoltSharp/Rest/Helpers/Servers/VoiceChannelHelper.cs
@@ -46,8 +46,8 @@ public static class VoiceChannelHelper
 
     internal static async Task<VoiceChannel> InternalCreateVoiceChannelAsync(this RevoltRestClient rest, string serverId, string name, string description = null)
     {
-        Conditions.ServerIdEmpty(serverId, "CreateVoiceChannelAsync");
-        Conditions.ChannelNameEmpty(name, "CreateVoiceChannelAsync");
+        Conditions.ServerIdEmpty(serverId, nameof(CreateVoiceChannelAsync));
+        Conditions.ChannelNameEmpty(name, nameof(CreateVoiceChannelAsync));
 
         CreateChannelRequest Req = new CreateChannelRequest
         {

--- a/RevoltSharp/Rest/IRevoltRequest.cs
+++ b/RevoltSharp/Rest/IRevoltRequest.cs
@@ -2,6 +2,6 @@
 
 /// <summary>
 /// Send a custom json body request to the Revolt instance API<br /><br />
-/// Use <see cref="RevoltRestClient.SendRequestAsync(RequestType, string, IRevoltRequest)"/> or <see cref="RevoltRestClient.SendRequestAsync{TResponse}(RevoltSharp.Rest.RequestType, string, RevoltSharp.Rest.IRevoltRequest)"/>
+/// Use <see cref="RevoltRestClient.SendRequestAsync(RequestType, string, IRevoltRequest)"/> or <see cref="RevoltRestClient.SendRequestAsync{TResponse}(RevoltSharp.Rest.RequestType, string, RevoltSharp.Rest.IRevoltRequest, bool)"/>
 /// </summary>
 public interface IRevoltRequest { }

--- a/RevoltSharp/Rest/RevoltRestClient.cs
+++ b/RevoltSharp/Rest/RevoltRestClient.cs
@@ -150,8 +150,8 @@ public class RevoltRestClient
     /// <exception cref="RevoltRestException"></exception>
     public async Task<FileAttachment> UploadFileAsync(byte[] bytes, string name, UploadFileType type)
     {
-        Conditions.FileBytesEmpty(bytes, "SendFileAsync");
-        Conditions.FileNameEmpty(name, "SendFileAsync");
+        Conditions.FileBytesEmpty(bytes, nameof(UploadFileAsync));
+        Conditions.FileNameEmpty(name, nameof(UploadFileAsync));
 
         HttpRequestMessage Mes = new HttpRequestMessage(HttpMethod.Post, GetUploadType(type));
         MultipartFormDataContent MP = new System.Net.Http.MultipartFormDataContent("file");

--- a/RevoltSharp/RevoltSharp.xml
+++ b/RevoltSharp/RevoltSharp.xml
@@ -946,6 +946,11 @@
             File has been reported by a user.
             </summary>
         </member>
+        <member name="M:RevoltSharp.Attachment.GetUrl(System.Nullable{System.Int32})">
+            <summary>
+            The URL of the attachment.
+            </summary>
+        </member>
         <member name="T:RevoltSharp.EmbedBuilder">
             <summary>
             Create a embed to use for messages
@@ -1245,6 +1250,16 @@
             Date of when the server was created.
             </summary>
         </member>
+        <member name="P:RevoltSharp.Server.Name">
+            <summary>
+            Name of the server
+            </summary>
+        </member>
+        <member name="P:RevoltSharp.Server.Description">
+            <summary>
+            Description for the server
+            </summary>
+        </member>
         <member name="P:RevoltSharp.ServerBan.Id">
             <summary>
             Id of the ban.
@@ -1253,6 +1268,16 @@
         <member name="P:RevoltSharp.ServerBan.CreatedAt">
             <summary>
             Date of when the ban occured.
+            </summary>
+        </member>
+        <member name="P:RevoltSharp.ServerBan.Username">
+            <summary>
+            Username of the banned user.
+            </summary>
+        </member>
+        <member name="P:RevoltSharp.ServerBan.Reason">
+            <summary>
+            Reason for ban creation.
             </summary>
         </member>
         <member name="T:RevoltSharp.ServerMember">
@@ -1311,16 +1336,16 @@
             Will be <see langword="null" /> if member has no avatar set.
             </remarks>
         </member>
-        <member name="M:RevoltSharp.ServerMember.GetDefaultAvatarUrl">
-            <inheritdoc cref="M:RevoltSharp.User.GetDefaultAvatarUrl" />
+        <member name="M:RevoltSharp.ServerMember.GetDefaultAvatarUrl(System.Nullable{System.Int32})">
+            <inheritdoc cref="M:RevoltSharp.User.GetDefaultAvatarUrl(System.Nullable{System.Int32})" />
         </member>
-        <member name="M:RevoltSharp.ServerMember.GetServerAvatarUrl">
+        <member name="M:RevoltSharp.ServerMember.GetServerAvatarUrl(System.Nullable{System.Int32})">
             <summary>
             Get the avatar url for this member, may be empty.
             </summary>
             <returns>URL of the image</returns>
         </member>
-        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrDefaultUrl">
+        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrDefaultUrl(System.Nullable{System.Int32})">
             <summary>
             Get the avatar url of this member or the default Revolt avatar.
             </summary>
@@ -1330,7 +1355,9 @@
             <summary>
             Get the avatar url for the member, parent user or default Revolt avatar.
             </summary>
-            <returns></returns>
+        </member>
+        <member name="M:RevoltSharp.ServerMember.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
+            <inheritdoc cref="M:RevoltSharp.User.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})"/>
         </member>
         <member name="P:RevoltSharp.ServerMember.RolesIds">
             <summary>
@@ -1342,7 +1369,7 @@
             The member is timed out/muted with the specified date time.
             </summary>
             <remarks>
-            <see cref="P:RevoltSharp.ServerMember.Timeout"/>.HasValue will be <see langword="false" /> if member is not timed out/muted.
+            Will be null if member is not timed out/muted.
             </remarks>
         </member>
         <member name="P:RevoltSharp.ServerMember.IsTimedOut">
@@ -1486,22 +1513,30 @@
             Will be <see langword="null" /> if the user has no custom avatar set.
             </remarks>
         </member>
-        <member name="M:RevoltSharp.User.GetDefaultAvatarUrl">
+        <member name="M:RevoltSharp.User.GetDefaultAvatarUrl(System.Nullable{System.Int32})">
             <summary>
             Get the default revolt avatar url for this user.
             </summary>
             <returns>URL of the image (No extension)</returns>
         </member>
-        <member name="M:RevoltSharp.User.GetAvatarUrl">
+        <member name="M:RevoltSharp.User.GetAvatarUrl(System.Nullable{System.Int32})">
             <summary>
             Get the user's custom avatar url, may be empty.
             </summary>
             <returns>URL of the image</returns>
         </member>
-        <member name="M:RevoltSharp.User.GetAvatarOrDefaultUrl">
+        <member name="M:RevoltSharp.User.GetAvatarOrDefaultUrl(System.Nullable{System.Int32})">
             <summary>
             Get the user's custom avatar url or the default revolt avatar url. 
             </summary>
+            <returns>URL of the image</returns>
+        </member>
+        <member name="M:RevoltSharp.User.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
+            <summary>
+            Gets the user's avatar.
+            </summary>
+            <param name="which">Which avatar to return.</param>
+            <param name="size"></param>
             <returns>URL of the image</returns>
         </member>
         <member name="P:RevoltSharp.User.Badges">
@@ -2781,7 +2816,7 @@
         <member name="T:RevoltSharp.Rest.IRevoltRequest">
             <summary>
             Send a custom json body request to the Revolt instance API<br /><br />
-            Use <see cref="M:RevoltSharp.Rest.RevoltRestClient.SendRequestAsync(RevoltSharp.Rest.RequestType,System.String,RevoltSharp.Rest.IRevoltRequest)"/> or <see cref="!:RevoltRestClient.SendRequestAsync&lt;TResponse&gt;(RevoltSharp.Rest.RequestType, string, RevoltSharp.Rest.IRevoltRequest)"/>
+            Use <see cref="M:RevoltSharp.Rest.RevoltRestClient.SendRequestAsync(RevoltSharp.Rest.RequestType,System.String,RevoltSharp.Rest.IRevoltRequest)"/> or <see cref="M:RevoltSharp.Rest.RevoltRestClient.SendRequestAsync``1(RevoltSharp.Rest.RequestType,System.String,RevoltSharp.Rest.IRevoltRequest,System.Boolean)"/>
             </summary>
         </member>
         <member name="T:RevoltSharp.Rest.RevoltRestClient">

--- a/RevoltSharp/RevoltSharp.xml
+++ b/RevoltSharp/RevoltSharp.xml
@@ -1336,28 +1336,8 @@
             Will be <see langword="null" /> if member has no avatar set.
             </remarks>
         </member>
-        <member name="M:RevoltSharp.ServerMember.GetDefaultAvatarUrl(System.Nullable{System.Int32})">
-            <inheritdoc cref="M:RevoltSharp.User.GetDefaultAvatarUrl(System.Nullable{System.Int32})" />
-        </member>
-        <member name="M:RevoltSharp.ServerMember.GetServerAvatarUrl(System.Nullable{System.Int32})">
-            <summary>
-            Get the avatar url for this member, may be empty.
-            </summary>
-            <returns>URL of the image</returns>
-        </member>
-        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrDefaultUrl(System.Nullable{System.Int32})">
-            <summary>
-            Get the avatar url of this member or the default Revolt avatar.
-            </summary>
-            <returns>URL of the image</returns>
-        </member>
-        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrUserAvatarOrDefaultUrl">
-            <summary>
-            Get the avatar url for the member, parent user or default Revolt avatar.
-            </summary>
-        </member>
-        <member name="M:RevoltSharp.ServerMember.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
-            <inheritdoc cref="M:RevoltSharp.User.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})"/>
+        <member name="M:RevoltSharp.ServerMember.GetAvatarUrl(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
+            <inheritdoc cref="M:RevoltSharp.User.GetAvatarURL(RevoltSharp.AvatarSources,System.Nullable{System.Int32})"/>
         </member>
         <member name="P:RevoltSharp.ServerMember.RolesIds">
             <summary>
@@ -1431,6 +1411,26 @@
         </member>
         <member name="P:RevoltSharp.ServerMember.MutualGroups">
             <inheritdoc cref="P:RevoltSharp.User.MutualGroups"/>
+        </member>
+        <member name="M:RevoltSharp.ServerMember.GetDefaultAvatarUrl(System.Nullable{System.Int32})">
+            <inheritdoc cref="M:RevoltSharp.User.GetDefaultAvatarUrl(System.Nullable{System.Int32})" />
+        </member>
+        <member name="M:RevoltSharp.ServerMember.GetServerAvatarUrl(System.Nullable{System.Int32})">
+            <summary>
+            Get the avatar url for this member, may be empty.
+            </summary>
+            <returns>URL of the image</returns>
+        </member>
+        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrDefaultUrl(System.Nullable{System.Int32})">
+            <summary>
+            Get the avatar url of this member or the default Revolt avatar.
+            </summary>
+            <returns>URL of the image</returns>
+        </member>
+        <member name="M:RevoltSharp.ServerMember.GetServerAvatarOrUserAvatarOrDefaultUrl">
+            <summary>
+            Get the avatar url for the member, parent user or default Revolt avatar.
+            </summary>
         </member>
         <member name="P:RevoltSharp.MessageUpdatedProperties.Id">
             <summary>
@@ -1519,19 +1519,13 @@
             </summary>
             <returns>URL of the image (No extension)</returns>
         </member>
-        <member name="M:RevoltSharp.User.GetAvatarUrl(System.Nullable{System.Int32})">
-            <summary>
-            Get the user's custom avatar url, may be empty.
-            </summary>
-            <returns>URL of the image</returns>
-        </member>
         <member name="M:RevoltSharp.User.GetAvatarOrDefaultUrl(System.Nullable{System.Int32})">
             <summary>
             Get the user's custom avatar url or the default revolt avatar url. 
             </summary>
             <returns>URL of the image</returns>
         </member>
-        <member name="M:RevoltSharp.User.GetAvatarUrlExt(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
+        <member name="M:RevoltSharp.User.GetAvatarURL(RevoltSharp.AvatarSources,System.Nullable{System.Int32})">
             <summary>
             Gets the user's avatar.
             </summary>

--- a/RevoltSharp/WebSocket/Events/Messages/MessageUpdateEventJson.cs
+++ b/RevoltSharp/WebSocket/Events/Messages/MessageUpdateEventJson.cs
@@ -7,13 +7,13 @@ namespace RevoltSharp.WebSocket.Events;
 internal class MessageUpdateEventJson
 {
     [JsonProperty("id")]
-    public string? MessageId;
+    public string MessageId = null!;
 
     [JsonProperty("channel")]
-    public string? ChannelId;
+    public string ChannelId = null!;
 
     [JsonProperty("data")]
-    public MessageUpdatedJson? Data;
+    public MessageUpdatedJson Data = null!;
 }
 internal class MessageUpdatedJson
 {

--- a/RevoltSharp/WebSocket/Events/Users/UserPlatformWipedEventJson.cs
+++ b/RevoltSharp/WebSocket/Events/Users/UserPlatformWipedEventJson.cs
@@ -5,5 +5,5 @@ namespace RevoltSharp.WebSocket.Events;
 internal class UserPlatformWipedEventJson
 {
     [JsonProperty("user_id")]
-    internal string? UserId;
+    internal string UserId = null!;
 }

--- a/RevoltSharp/WebSocket/RevoltSocketClient.cs
+++ b/RevoltSharp/WebSocket/RevoltSocketClient.cs
@@ -797,17 +797,21 @@ internal class RevoltSocketClient
                             return;
                         if (@event.Clear.HasValue)
                         {
-                            if (@event.Clear.Value.Contains("ProfileContent"))
-                                @event.Data.ProfileContent = Optional.Some<string>("");
+                            string[] clr = @event.Clear.Value;
+                            if (@event.Data.Profile.HasValue)
+                            {
+                                if (clr.Contains("ProfileContent"))
+                                    @event.Data.Profile.Value.Content = null;
 
-                            if (@event.Clear.Value.Contains("StatusText"))
-                                @event.Data.status = Optional.Some<UserStatusJson>(new UserStatusJson { Text = null });
+                                if (clr.Contains("ProfileBackground"))
+                                    @event.Data.Profile.Value.Background = null;
+                            }
 
-                            if (@event.Clear.Value.Contains("ProfileBackground"))
-                                @event.Data.ProfileBackground = Optional.Some<AttachmentJson>(null);
+                            if (clr.Contains("StatusText"))
+                                @event.Data.Status = Optional.Some(new UserStatusJson());
 
-                            if (@event.Clear.Value.Contains("Avatar"))
-                                @event.Data.avatar = Optional.Some<AttachmentJson>(null);
+                            if (clr.Contains("Avatar"))
+                                @event.Data.Avatar = Optional.Some<AttachmentJson>(null);
                         }
                         if (@event.Id == CurrentUser.Id)
                         {

--- a/TestBot/Commands/CmdTest.cs
+++ b/TestBot/Commands/CmdTest.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿#pragma warning disable CS1998
+
+using Newtonsoft.Json;
 using RevoltSharp;
 using RevoltSharp.Commands;
 using RevoltSharp.Rest;


### PR DESCRIPTION
- Nullable cleanups everywhere. All methods and fields should now be correctly marked whether or not they can be null.
- Removed `SelfUser.GetDMChannelAsync`, `SelfUser.BlockAsync`, and `SelfUser.UnBlockAsync`.
- Raise an exception when the client tries to call `RevoltRestClient.BlockUserAsync` on itself (ditto for unblock).
- **BREAKING**: Replaced `GetAvatarUrl` with a new method with a parameter to specify which avatar(s) to try acquire (server - > user -> default -> null).
- Marked the other avatar methods as obsolete.
- All condition calls will now use `nameof` instead of string literals. 4 incorrect literals were discovered this way.
- Fixed `ChannelPermissions` ignoring its `server` parameter.
- Added a `size` parameter to `Attachment.GetUrl` and its various callers, including GetAvatar, GetBanner, GetIcon, etc.
- Regenerated documentation.