### PR TITLE
Added additional checks on null values coming back in UserUpdate payload

### DIFF
--- a/RevoltSharp/Core/Updated/SelfUserUpdatedProperties.cs
+++ b/RevoltSharp/Core/Updated/SelfUserUpdatedProperties.cs
@@ -2,15 +2,16 @@
 
 namespace RevoltSharp;
 
-
 public class SelfUserUpdatedProperties : UserUpdatedProperties
 {
     internal SelfUserUpdatedProperties(RevoltClient client, PartialUserJson json) : base(client, json)
     {
-        ProfileContent = json.Profile.Value.Content;
-        if (json.Profile.Value.Background.HasValue)
+        if (json.Profile.HasValue)
+            ProfileContent = json.Profile.Value.Content;
+        
+        if (json.Profile.HasValue && 
+            json.Profile.Value.Background.HasValue)
             ProfileBackground = Optional.Some(Attachment.Create(client, json.Profile.Value.Background.Value));
-
     }
 
     public Optional<string?> ProfileContent;


### PR DESCRIPTION
When trying to update the bot users status, I was receiving the following errors in my output:

![image](https://github.com/user-attachments/assets/4da170bc-2242-46f4-bd6d-2f435aef9128)

When receiving this error, the bot would continue to function but the update of the bot users status didn't complete.

Running the TestBot, I was able to isolate the issue to this line of code:

`ProfileContent = json.Profile.Value.Content;`

Once wrapped in checks to ensure data was what we needed to see before assigning values, the users status message was successfully set AND the bot continued to function without issue.