### PR TITLE
Fix API URL and increment version

### DIFF
--- a/RevoltSharp/Client/ClientConfig.cs
+++ b/RevoltSharp/Client/ClientConfig.cs
@@ -28,7 +28,7 @@ public class ClientConfig
     /// <summary>
     /// Do not change this unless you know what you're doing.
     /// </summary>
-    public string ApiUrl = "https://api.revolt.chat/0.8/";
+    public string ApiUrl = "https://api.revolt.chat/";
 
     /// <summary>
     /// Do not use this unless you know what you're doing.

--- a/RevoltSharp/RevoltSharp.csproj
+++ b/RevoltSharp/RevoltSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
 	  <ImplicitUsings>disable</ImplicitUsings>
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
     <Authors>Builderb (Fluxpoint Development)</Authors>
     <Company>Fluxpoint Development</Company>
     <Description>A C# lib for using the revolt chat API and connecting to the gateway with a user or bot account.</Description>


### PR DESCRIPTION
note: the `/0.8/` URL does work (although when I first tried it, it didn't) but for futureproof sake, we should still just use `/` as that's what the client & frontend use anyway and there is no point changing a version number in code when the API updates as i'm sure you don't want to maintain this every time the version number changes and nothing affects API code